### PR TITLE
Fix v1.3 release UI version marker

### DIFF
--- a/toolknit-desktop/index.html
+++ b/toolknit-desktop/index.html
@@ -53,7 +53,7 @@
             <p data-i18n="settings.centerDesc">管理 AI 密钥、依赖、存储、背景和窗口外观。所有设置只保存在本机。</p>
             <div class="settings-poster-meta">
               <span data-i18n="settings.versionInfo">版本信息</span>
-              <strong>v1.3.0</strong>
+              <strong class="settings-version">v1.3.0</strong>
             </div>
           </div>
         </aside>
@@ -70,7 +70,7 @@
           <div class="settings-section settings-section-ai">
             <h3 class="settings-section-title" data-i18n="settings.aiFeatures">AI 功能</h3>
             <div class="settings-row">
-              <span class="settings-version" data-i18n="settings.aiFeaturesDesc">配置本地 AI 平台密钥</span>
+              <span class="settings-path" data-i18n="settings.aiFeaturesDesc">配置本地 AI 平台密钥</span>
               <button class="settings-btn" id="settingsApiKey" data-i18n="settings.configureApiKey">配置密钥</button>
             </div>
           </div>


### PR DESCRIPTION
Fix the settings UI version marker expected by the release workflow. The AI settings description should not reuse the settings-version class.