### PR TITLE
fix(ui): add settings-version id for release validation

### DIFF
--- a/toolknit-desktop/index.html
+++ b/toolknit-desktop/index.html
@@ -94,7 +94,7 @@
               <p data-i18n="settings.centerDesc">管理 AI 密钥、依赖、存储和窗口外观。所有设置只保存在本机。</p>
               <div class="settings-v2-poster-note" data-i18n="settings.posterNote">这一版不再放“自定义背景”，保持统一的黑白极简视觉。</div>
               <div class="settings-v2-poster-meta">
-                <div><span data-i18n="settings.versionInfo">版本信息</span><strong>v2.0.0</strong></div>
+                <div><span data-i18n="settings.versionInfo">版本信息</span><strong id="settings-version">v2.0.0</strong></div>
                 <div><span data-i18n="settings.storageMeta">保存位置</span><strong>LOCAL</strong></div>
                 <div><span data-i18n="settings.visualMeta">视觉方向</span><strong>MONOCHROME</strong></div>
               </div>


### PR DESCRIPTION
补一个稳定的 settings-version 标识，让 release.yml 的版本一致性校验能匹配当前 2.0 设置页的版本信息。