### PR TITLE
feat: 集成图论与魔方工具

### DIFF
--- a/toolknit-desktop/index.html
+++ b/toolknit-desktop/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./src/pdf-page-number.css">
     <link rel="stylesheet" href="./src/pdf-crop.css">
     <link rel="stylesheet" href="./src/teleprompter.css">
+  <link rel="stylesheet" href="./src/rubiks-cube.css">
     <link rel="stylesheet" href="./src/tool-custom-select.css">
     <link rel="stylesheet" href="./src/tool-waveform-slider.css">
     <link rel="stylesheet" href="./src/bg-removal.css">
@@ -466,6 +467,7 @@
             <div class="help-nav-item" data-help-section="color-extractor" data-i18n="help.nav.colorExtractor">配色提取器</div>
             <div class="help-nav-item" data-help-section="color-space-compare" data-i18n="help.nav.colorSpaceCompare">颜色空间对比</div>
             <div class="help-nav-item" data-help-section="typing-test" data-i18n="help.nav.typingTest">打字测试器</div>
+            <div class="help-nav-item" data-help-section="rubiks-cube">图论与魔方</div>
           </div>
           <div class="help-nav-group">
             <div class="help-nav-group-title" data-i18n="help.group.cleanupTools">清理工具</div>
@@ -9734,6 +9736,19 @@
                     <div class="audio-list-meta" data-i18n="home.toolNames.typingTestMeta">中英文词库 / 难度分级 / 音效反馈</div>
                   </div>
                 </div>
+                <div class="audio-list-item" data-tool="rubiks-cube" role="button" tabindex="0" aria-label="图论与魔方">
+                  <div class="audio-list-icon"><i data-lucide="box"></i></div>
+                  <div class="audio-list-info">
+                    <div class="audio-list-title">图论与魔方</div>
+                    <div class="audio-list-desc">2D 展开图与 3D 魔方实时联动，支持 2–7 阶，内置复原公式速查</div>
+                  </div>
+                  <div class="audio-list-right">
+                    <div class="audio-list-tags">
+                      <span class="audio-tag">创意工具</span>
+                    </div>
+                    <div class="audio-list-meta">2D/3D 联动 · 2–7 阶 · 公式速查</div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -10011,6 +10026,228 @@
 
     <script type="module" src="./src/help-data.js"></script>
     <script type="module" src="./src/main.js"></script>
+
+<!-- ===== 图论与魔方 · 创意工具 ===== -->
+<div class="pdf-merge-overlay pdf-merge-v2 rubiks-cube-v2" id="rubiksCubeOverlay">
+  <div class="plasma-bg pdf-merge-v2-bg" id="rubiksCubeBg"></div>
+  <header class="pdf-merge-v2-topbar rubiks-cube-topbar">
+    <div class="pdf-merge-v2-topbar-left">
+      <button class="settings-v2-back settings-back pdf-merge-v2-back" id="rubiksCubeBack" type="button" title="返回首页">
+        <i data-lucide="arrow-left"></i>
+        <span>返回首页</span>
+      </button>
+      <span class="pdf-merge-v2-top-tag">RUBIK LAB · TOOL PAGE 2.3</span>
+    </div>
+    <div class="home-v2-top-actions pdf-merge-v2-top-actions">
+      <button class="home-v2-icon-button" id="rubiksCubeV2Settings" type="button" title="设置" aria-label="设置"><i data-lucide="settings"></i></button>
+      <div class="home-v2-window-controls" aria-label="窗口控制">
+        <button class="home-v2-window-button ctrl-btn" type="button" title="最小化" data-action="minimize"><i data-lucide="minus"></i></button>
+        <button class="home-v2-window-button ctrl-btn" type="button" title="放大" data-action="maximize"><i data-lucide="square"></i></button>
+        <button class="home-v2-window-button ctrl-btn" type="button" title="关闭" data-action="close"><i data-lucide="x"></i></button>
+      </div>
+    </div>
+  </header>
+  <div class="pdf-merge-v2-body rubiks-cube-body">
+    <aside class="pdf-merge-v2-poster rubiks-cube-poster" aria-label="图论与魔方说明">
+      <div class="pdf-merge-v2-poster-kicker">NxN CUBE LAB</div>
+      <h1 class="pdf-merge-v2-title">图论与魔方</h1>
+      <p class="pdf-merge-v2-subtitle">2D 展开图与 3D 魔方实时联动，支持 2–7 阶，内置复原公式速查。</p>
+      <div class="pdf-merge-v2-poster-note">
+        <span>CUBE WORKFLOW</span>
+        <strong>选择阶数与转动层，通过按钮、键盘或拖拽操控魔方，对照复原公式逐步还原。</strong>
+      </div>
+      <div class="pdf-merge-v2-steps">
+        <div class="pdf-merge-v2-step is-active"><span>01</span><div><strong>选择阶数</strong><p>2–7 阶自由切换。</p></div></div>
+        <div class="pdf-merge-v2-step"><span>02</span><div><strong>操控转动</strong><p>按钮 / 键盘 / 拖拽。</p></div></div>
+        <div class="pdf-merge-v2-step"><span>03</span><div><strong>对照还原</strong><p>层先法 / CFOP 公式。</p></div></div>
+      </div>
+    </aside>
+    <main class="pdf-merge-v2-workspace rubiks-cube-workspace">
+      <div class="rubiks-app">
+        <header class="rubiks-header">
+          <div class="rubiks-toolbar">
+            <div class="size-switch">
+              <span class="lbl">阶数</span>
+              <button data-size="2">2</button>
+              <button data-size="3" class="active">3</button>
+              <button data-size="4">4</button>
+              <button data-size="5">5</button>
+              <button data-size="6">6</button>
+              <button data-size="7">7</button>
+            </div>
+            <button class="btn primary" id="formulaBtn">复原公式</button>
+            <button class="btn primary" id="scrambleBtn">打乱</button>
+            <button class="btn" id="resetBtn">还原</button>
+            <div class="rubiks-stats">
+              <span>打乱 <b id="scrambleCount">0</b> 步</span>
+              <span>还原 <b id="moveCount">0</b> 步</span>
+              <span id="solvedBadge">已还原</span>
+            </div>
+          </div>
+        </header>
+
+        <main class="rubiks-main">
+          <section class="panel net-panel">
+            <div class="panel-head">
+              <span class="panel-title">二维展开图</span>
+              <span class="panel-hint">点击色块选中对应面 · 与下方三维一一对应</span>
+            </div>
+            <div class="net-stage">
+              <svg class="graph-bg" id="graphBg" aria-hidden="true"></svg>
+              <svg id="net" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="魔方二维展开图"></svg>
+            </div>
+          </section>
+
+          <section class="panel cube-panel">
+            <div class="panel-head">
+              <span class="panel-title">三维魔方</span>
+              <span class="panel-hint">左键选面 · 右键选纵向层 · 色块拖拽转动该层 · 空白拖拽旋转视角 · 滚轮缩放</span>
+            </div>
+            <div class="cube-stage" id="cubeStage">
+              <div class="cube-hint">左键选面 · 右键选纵向层 · 拖拽色块转动 · 拖拽空白旋转视角</div>
+            </div>
+          </section>
+        </main>
+
+        <footer class="rubiks-footer">
+          <div class="ctl-row">
+            <span class="ctl-label">面</span>
+            <div class="chips" id="faceBtns">
+              <button class="chip face-U" data-face="U">U</button>
+              <button class="chip face-D" data-face="D">D</button>
+              <button class="chip face-L" data-face="L">L</button>
+              <button class="chip face-R" data-face="R">R</button>
+              <button class="chip face-F" data-face="F">F</button>
+              <button class="chip face-B" data-face="B">B</button>
+            </div>
+          </div>
+          <div class="ctl-row">
+            <span class="ctl-label">轴/层</span>
+            <div class="chips" id="axisBtns">
+              <button class="chip" data-axis="x">X</button>
+              <button class="chip active" data-axis="y">Y</button>
+              <button class="chip" data-axis="z">Z</button>
+            </div>
+            <div class="chips" id="layerBtns"></div>
+          </div>
+          <div class="ctl-row">
+            <span class="ctl-label">转动</span>
+            <div class="rotate-group">
+              <button class="rotate-btn" id="ccwBtn">逆时针</button>
+              <button class="rotate-btn" id="cwBtn">顺时针</button>
+            </div>
+            <span class="sel-info" id="selInfo">未选择 · 点击魔方或展开图选层</span>
+          </div>
+          <div class="ctl-row key-hint">
+            <span class="ctl-label">键盘</span>
+            <span class="key-text"><b>W</b>/<b>S</b> 上·下 &nbsp; <b>A</b>/<b>D</b> 左·右 &nbsp; <b>Q</b>/<b>E</b> 前·后 &nbsp; <b>R</b> 切向(横Y/纵X/面Z) &nbsp; <b>Ctrl</b> 逆时针&nbsp; <b>Space</b> 顺时针&nbsp; <b>1</b>-<b>7</b> 数字选层</span>
+          </div>
+        </footer>
+      </div>
+
+      <!-- 魔方复原公式面板（3 阶默认；2/4/5/高阶由核心按阶数替换） -->
+      <div class="modal-mask" id="formulaModal" hidden>
+        <div class="modal">
+          <div class="modal-head">
+            <div>
+              <div class="modal-title">魔方复原公式</div>
+              <div class="modal-sub">WCA 记号：R/L/U/D/F/B = 面向该面顺时针 · <b>'</b> 逆时针 · <b>2</b> 转180° · <b>M</b> 中层 · <b>f/r</b> 等小写字母转两层 · 点击公式可复制</div>
+            </div>
+            <button class="modal-close" id="formulaClose" aria-label="关闭">×</button>
+          </div>
+          <div class="modal-tabs" id="formulaTabs">
+            <button class="tab active" data-tab="basic">层先法 · 入门</button>
+            <button class="tab" data-tab="f2l">CFOP · F2L</button>
+            <button class="tab" data-tab="oll">CFOP · OLL</button>
+            <button class="tab" data-tab="pll">CFOP · PLL</button>
+            <button class="tab" data-tab="other">其他方法</button>
+          </div>
+          <div class="modal-body">
+
+            <div class="tab-pane active" id="pane-basic">
+              <div class="sec-label">1 · 底层十字</div>
+              <div class="fc"><span class="fc-name">底层十字</span><span class="fc-note">无固定公式：拼出白十字，并让棱块侧面与中心块对齐</span></div>
+              <div class="sec-label">2 · 底层角块</div>
+              <div class="fc"><span class="fc-name">右手插入</span><div class="fc-alg" data-alg="R U R' U'"><code>R U R' U'</code><span class="copy-tip"></span></div><span class="fc-note">白在侧面时重复至归位</span></div>
+              <div class="fc"><span class="fc-name">左手插入</span><div class="fc-alg" data-alg="L' U' L U"><code>L' U' L U</code><span class="copy-tip"></span></div><span class="fc-note">镜像情况</span></div>
+              <div class="sec-label">3 · 中层棱块</div>
+              <div class="fc"><span class="fc-name">往右归位</span><div class="fc-alg" data-alg="U R U' R' U' F' U F"><code>U R U' R' U' F' U F</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">往左归位</span><div class="fc-alg" data-alg="U' F' U F U R U' R'"><code>U' F' U F U R U' R'</code><span class="copy-tip"></span></div></div>
+              <div class="sec-label">4 · 顶层十字</div>
+              <div class="fc"><span class="fc-name">顶层十字</span><div class="fc-alg" data-alg="F R U R' U' F'"><code>F R U R' U' F'</code><span class="copy-tip"></span></div><span class="fc-note">重复：点左面 L 再一次出十字</span></div>
+              <div class="sec-label">5 · 顶面翻角</div>
+              <div class="fc"><span class="fc-name">正小鱼 Sune</span><div class="fc-alg" data-alg="R U R' U R U2 R'"><code>R U R' U R U2 R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">反小鱼</span><div class="fc-alg" data-alg="R U2 R' U' R U' R'"><code>R U2 R' U' R U' R'</code><span class="copy-tip"></span></div></div>
+              <div class="sec-label">6 · 顶层角块归位</div>
+              <div class="fc"><span class="fc-name">同面交换</span><div class="fc-alg" data-alg="R U R' U' R' F R2 U' R' U' R U R' F'"><code>R U R' U' R' F R2 U' R' U' R U R' F'</code><span class="copy-tip"></span></div><span class="fc-note">「头灯」一面放后</span></div>
+              <div class="fc"><span class="fc-name">对角交换</span><div class="fc-alg" data-alg="F R U' R' U' R U R' F' R U R' U' R' F R F'"><code>F R U' R' U' R U R' F' R U R' U' R' F R F'</code><span class="copy-tip"></span></div></div>
+              <div class="sec-label">7 · 顶层棱块归位</div>
+              <div class="fc"><span class="fc-name">三棱逆时针</span><div class="fc-alg" data-alg="R U' R U R U R U' R' U' R2"><code>R U' R U R U R U' R' U' R2</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">三棱顺时针</span><div class="fc-alg" data-alg="R2 U R U R' U' R' U' R' U R'"><code>R2 U R U R' U' R' U' R' U R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">对棱互换 H</span><div class="fc-alg" data-alg="M2 U M2 U2 M2 U M2"><code>M2 U M2 U2 M2 U M2</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">邻棱互换 Z</span><div class="fc-alg" data-alg="M2 U M2 U M' U2 M2 U2 M' U2"><code>M2 U M2 U M' U2 M2 U2 M' U2</code><span class="copy-tip"></span></div></div>
+            </div>
+
+            <div class="tab-pane" id="pane-f2l">
+              <div class="fc-note-only">F2L = 前两层：把「底层角块 + 中层棱块」配成一对后一次插入，共 41 种情况。入门先记下面几个高频公式，其余靠直觉推导即可（速拧稳定后逐条记忆）</div>
+              <div class="sec-label">核心手法</div>
+              <div class="fc"><span class="fc-name">基本插入</span><div class="fc-alg" data-alg="R U R'"><code>R U R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">反向插入</span><div class="fc-alg" data-alg="R U' R'"><code>R U' R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">配对前奏</span><div class="fc-alg" data-alg="y' R U R'"><code>y' R U R'</code><span class="copy-tip"></span></div><span class="fc-note">如 F U F'，把角棱移到一起</span></div>
+              <div class="sec-label">典型 Case</div>
+              <div class="fc"><span class="fc-name">已配对直接插入</span><div class="fc-alg" data-alg="R U R'"><code>R U R'</code><span class="copy-tip"></span></div><span class="fc-note">角在 URF、棱在 UR</span></div>
+              <div class="fc"><span class="fc-name">角在顶、白朝上</span><div class="fc-alg" data-alg="(R U2 R' U)2 y' R' U' R"><code>(R U2 R' U)2 y' R' U' R</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">角在顶、白朝侧</span><div class="fc-alg" data-alg="U R U' R' U' F' U F"><code>U R U' R' U' F' U F</code><span class="copy-tip"></span></div></div>
+            </div>
+
+            <div class="tab-pane" id="pane-oll">
+              <div class="fc-note-only">完整 OLL 有 57 种，先学 2-Look OLL（10 条）：先做顶面十字，再用 7 条公式翻好角块</div>
+              <div class="sec-label">A · 顶面十字（3）</div>
+              <div class="fc"><span class="fc-name">横线（一字）</span><div class="fc-alg" data-alg="F R U R' U' F'"><code>F R U R' U' F'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">L 形（直角）</span><div class="fc-alg" data-alg="F U R U' R' F'"><code>F U R U' R' F'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">点型</span><div class="fc-alg" data-alg="F R U R' U' F' f R U R' U' f'"><code>F R U R' U' F' f R U R' U' f'</code><span class="copy-tip"></span></div><span class="fc-note">分两步做：先横线再 L</span></div>
+              <div class="sec-label">B · 顶面翻角（7）</div>
+              <div class="fc"><span class="fc-name">正小鱼 Sune</span><div class="fc-alg" data-alg="R U R' U R U2 R'"><code>R U R' U R U2 R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">反小鱼</span><div class="fc-alg" data-alg="R U2 R' U' R U' R'"><code>R U2 R' U' R U' R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">双对称十字</span><div class="fc-alg" data-alg="R U2 R' U' R U R' U' R U' R'"><code>R U2 R' U' R U R' U' R U' R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">单对称十字</span><div class="fc-alg" data-alg="R U2 R2 U' R2 U' R2 U2 R"><code>R U2 R2 U' R2 U' R2 U2 R</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">同向由字</span><div class="fc-alg" data-alg="R2 D' R U2 R' D R U2 R"><code>R2 D' R U2 R' D R U2 R</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">对向由字</span><div class="fc-alg" data-alg="r U R' U' r' F R F'"><code>r U R' U' r' F R F'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">梅花七</span><div class="fc-alg" data-alg="F' r U R' U' r' F R"><code>F' r U R' U' r' F R</code><span class="copy-tip"></span></div></div>
+            </div>
+
+            <div class="tab-pane" id="pane-pll">
+              <div class="fc-note-only">完整 PLL 有 21 种，先学 2-Look PLL（6 条）：先归位角块，再归位棱块</div>
+              <div class="sec-label">A · 顶层角块（2）</div>
+              <div class="fc"><span class="fc-name">同面交换 T</span><div class="fc-alg" data-alg="R U R' U' R' F R2 U' R' U' R U R' F'"><code>R U R' U' R' F R2 U' R' U' R U R' F'</code><span class="copy-tip"></span></div><span class="fc-note">「头灯」放后</span></div>
+              <div class="fc"><span class="fc-name">对角交换 Y</span><div class="fc-alg" data-alg="F R U' R' U' R U R' F' R U R' U' R' F R F'"><code>F R U' R' U' R U R' F' R U R' U' R' F R F'</code><span class="copy-tip"></span></div></div>
+              <div class="sec-label">B · 顶层棱块（4）</div>
+              <div class="fc"><span class="fc-name">三棱逆时针 Ua</span><div class="fc-alg" data-alg="R U' R U R U R U' R' U' R2"><code>R U' R U R U R U' R' U' R2</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">三棱顺时针 Ub</span><div class="fc-alg" data-alg="R2 U R U R' U' R' U' R' U R'"><code>R2 U R U R' U' R' U' R' U R'</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">对棱互换 H</span><div class="fc-alg" data-alg="M2 U M2 U2 M2 U M2"><code>M2 U M2 U2 M2 U M2</code><span class="copy-tip"></span></div></div>
+              <div class="fc"><span class="fc-name">邻棱互换 Z</span><div class="fc-alg" data-alg="M2 U M2 U M' U2 M2 U2 M' U2"><code>M2 U M2 U M' U2 M2 U2 M' U2</code><span class="copy-tip"></span></div></div>
+            </div>
+
+            <div class="tab-pane" id="pane-other">
+              <div class="fc-note-only">除 CFOP 外，常用的还有以下几种解法，思路不同、各有所长：</div>
+              <div class="sec-label">桥式 Roux</div>
+              <div class="fc-note-only">先搭左右两个「桥」（每桥 1×2×3 块），再以 CMLL 一次处理顶层角块，最后用 LSE（6 棱）收尾。公式量少、转动多在中层 M 层，适合单手与部分竞速选手</div>
+              <div class="sec-label">ZZ</div>
+              <div class="fc-note-only">先用 EOLine 一次性解决所有棱块朝向并搭好底面竖线，之后可整层转 R U L 完成前两层，顶层通常用 ZBLL。预判好、转动较少</div>
+              <div class="sec-label">角先法 / 8355</div>
+              <div class="fc-note-only">先从角块入手，再处理棱块；公式极少（8355 法仅 3 条核心公式），适合入门过渡，速度上限低于 CFOP</div>
+              <div class="sec-label">学习方法建议</div>
+              <div class="fc-note-only">零基础：先用「层先法」完整还原一次；想提速：改用 2-Look CFOP（本面板 OLL/PLL 标签即可覆盖）；稳定进 30 秒后再逐步背完 57 条 OLL 与 21 条 PLL</div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+  <script type="module" src="./src/rubiks-cube-ui.js"></script>
 
     <div class="audio-convert-process-mask" id="audioConvertProcessMask">
       <div class="tk-mascot-lg" aria-hidden="true"></div>

--- a/toolknit-desktop/package-lock.json
+++ b/toolknit-desktop/package-lock.json
@@ -43,7 +43,7 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
-        "vite": "^8.2.0"
+        "vite": "^8.2.2"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -463,9 +463,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -485,9 +482,6 @@
       "integrity": "sha512-yYkPbJDJiWj6N0gASA3CAvRypZmVpJnxU0DQg3aBhneLDQde9TPLKADsQkobNoJUtTT/lj46aWpzT48PDb3Qcg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -509,9 +503,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -532,9 +523,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -554,9 +542,6 @@
       "integrity": "sha512-hb20MxKXXb5IB7AAwN8UHz9WRsa2HmdZfjsDCzjElwJoeV1aotVEwFU4FrFQcYQVzsJQLeaCc/2Qdt/0Q72mMg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -636,13 +621,13 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
-      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
       "dev": true,
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       }
     },
     "node_modules/@pdf-lib/fontkit": {
@@ -672,10 +657,27 @@
         "pako": "^1.0.10"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
-      "integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
       "cpu": [
         "arm64"
       ],
@@ -690,9 +692,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
-      "integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
       "cpu": [
         "arm64"
       ],
@@ -707,9 +709,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
-      "integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
       "cpu": [
         "x64"
       ],
@@ -724,9 +726,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
-      "integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
       "cpu": [
         "x64"
       ],
@@ -741,9 +743,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
-      "integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
       "cpu": [
         "arm"
       ],
@@ -758,16 +760,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
-      "integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -778,16 +777,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
-      "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -798,16 +794,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
-      "integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -818,16 +811,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
-      "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -838,16 +828,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
-      "integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -858,16 +845,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
-      "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -878,9 +862,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
-      "integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
       "cpu": [
         "arm64"
       ],
@@ -895,9 +879,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
-      "integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
       "cpu": [
         "arm64"
       ],
@@ -912,9 +896,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
-      "integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
       "cpu": [
         "x64"
       ],
@@ -930,7 +914,7 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
@@ -2937,9 +2921,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2961,9 +2942,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2985,9 +2963,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3009,9 +2984,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3321,7 +3293,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.18.tgz",
       "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
@@ -3462,9 +3434,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -3482,7 +3454,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3584,13 +3556,13 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
-      "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.142.0",
+        "@oxc-project/types": "=0.148.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3600,20 +3572,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.2",
-        "@rolldown/binding-darwin-arm64": "1.2.2",
-        "@rolldown/binding-darwin-x64": "1.2.2",
-        "@rolldown/binding-freebsd-x64": "1.2.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
-        "@rolldown/binding-linux-arm64-musl": "1.2.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
-        "@rolldown/binding-linux-x64-gnu": "1.2.2",
-        "@rolldown/binding-linux-x64-musl": "1.2.2",
-        "@rolldown/binding-openharmony-arm64": "1.2.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
-        "@rolldown/binding-win32-x64-msvc": "1.2.2"
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
       }
     },
     "node_modules/roughjs": {
@@ -3911,16 +3884,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
-      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmmirror.com/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.23",
-        "rolldown": "~1.2.0",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -3937,7 +3910,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/toolknit-desktop/package.json
+++ b/toolknit-desktop/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.0.0",
-    "vite": "^8.2.0"
+    "vite": "^8.2.2"
   },
   "dependencies": {
     "@codemirror/commands": "^6.11.0",

--- a/toolknit-desktop/src/help-data.js
+++ b/toolknit-desktop/src/help-data.js
@@ -780,6 +780,11 @@ toolknit ppt draft --outline-file outline.json --output-dir out --theme minimal-
     html: `<div class="help-doc"><h2>打字测试器</h2><p>选择中文或英文、难度和时长后开始输入，实时显示速度和准确率。</p><h3>使用方法</h3><ol class="help-steps"><li>设置语言、难度与测试时长</li><li>点击“开始测试”，再点击输入区域开始打字</li><li>结束后查看 WPM、准确率等结果；需要重测时点击“重新开始”</li></ol><div class="help-note"><p>这是桌面端的交互工具，不提供 CLI 或 IDE Agent 调用。</p></div></div>`
   },
 
+  'rubiks-cube': {
+    title: '图论与魔方',
+    html: `<div class="help-doc"><h2>图论与魔方</h2><p>上方二维展开图与下方三维魔方实时联动，支持 2–7 阶，内置层先法与 CFOP 复原公式速查。</p><h3>界面说明</h3><ol class="help-steps"><li><strong>二维展开图</strong>：六面平铺展示，点击色块可选中对应面</li><li><strong>三维魔方</strong>：可旋转视角、缩放，色块与展开图一一对应</li><li><strong>底部控件</strong>：面 / 轴 / 层选择 + 顺逆时针转动按钮</li></ol><h3>操控方式</h3><ol class="help-steps"><li><strong>鼠标</strong>：左键点击色块选中面，右键选中纵向层，拖拽色块转动该层，拖拽空白旋转视角</li><li><strong>键盘</strong>：W/S 上下、A/D 左右、Q/E 前后选择层位；R 切换横Y/纵X/面Z；Ctrl 逆时针、Space 顺时针；数字 1–7 直接选层</li><li><strong>按钮</strong>：顶部阶数切换、打乱、还原、复原公式面板</li></ol><h3>复原公式</h3><p>点击右上角"复原公式"打开速查面板，包含层先法七步、CFOP 的 F2L/OLL/PLL 以及桥式、ZZ 等其他方法，每条公式附 U/F 面情况示意图，点击公式可复制。</p><div class="help-note"><p>打乱步数与还原步数分开计数；公式面板中的情况图以黄色为顶面、蓝色为前面。这是桌面端交互工具，不提供 CLI 或 IDE Agent 调用。</p></div></div>`
+  },
+
   'ai-polish': {
     title: 'AI 文字润色',
     html: `<div class="help-doc">

--- a/toolknit-desktop/src/rubiks-cube-core.js
+++ b/toolknit-desktop/src/rubiks-cube-core.js
@@ -1,0 +1,1089 @@
+/* ============================================================
+ * rubiks-cube-core.js —— 图论与魔方 · 核心逻辑
+ * 移植自 HBuilderX 版 app.js，按 ToolKnit 项目风格拆分为 core 模块
+ * 模型：物理小方块（缩放 2 倍整数坐标，偶数阶精确）
+ * 2D 展开图与 3D 视图共享同一份状态，实时联动
+ * 依赖：three（npm 依赖，ES module import）
+ * 导出：initRubiksCube(rootEl) / disposeRubiksCube()
+ * ============================================================ */
+'use strict';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+/* ---------- 常量 ---------- */
+const DIRV = {'+x':[1,0,0],'-x':[-1,0,0],'+y':[0,1,0],'-y':[0,-1,0],'+z':[0,0,1],'-z':[0,0,-1]};
+const AXIS_IDX = {x:0, y:1, z:2};
+const AXES = ['x','y','z'];
+const FACES = ['U','D','F','B','L','R'];
+const FACE_CN = {U:'上', D:'下', F:'前', B:'后', L:'左', R:'右'};
+const FACE_COLOR = {U:'#ffd500', D:'#f5f5f5', F:'#0051ba', B:'#009b48', R:'#c41e3a', L:'#ff5800', K:'#141a2c'};
+const FACE_ANGLE = {U:-90, D:90, R:-90, L:90, F:-90, B:90};
+const FACE_AXIS =  {U:'y', D:'y', R:'x', L:'x', F:'z', B:'z'};
+
+/* ---------- 状态 ---------- */
+let N = 3;
+let cubies = [];
+let selected = null;
+let layerMem = {};
+let uiAxis = 'y';
+let moveCount = 0;
+let scrambleCount = 0;
+let skipMoves = 0;
+let initialized = false;
+let rootEl = null;
+
+/* ---------- DOM（init 时绑定） ---------- */
+let stageEl = null, canvasEl = null, netSvg = null, graphSvg = null;
+let formulaModal = null, formulaTabs = null, formulaBody = null;
+
+function $(sel) { return rootEl.querySelector(sel); }
+function $all(sel) { return rootEl.querySelectorAll(sel); }
+
+/* ---------- 模型（已验证） ---------- */
+function faceKey(axis, sgn, coord, max) {
+  const atMax = Math.abs(coord - max) < 1e-9;
+  const atMin = Math.abs(coord + max) < 1e-9;
+  if (!atMax && !atMin) return 'K';
+  const map = {x:{1:'R','-1':'L'}, y:{1:'U','-1':'D'}, z:{1:'F','-1':'B'}};
+  return map[axis][sgn];
+}
+function axisVec(axis) {
+  return new THREE.Vector3(axis==='x'?1:0, axis==='y'?1:0, axis==='z'?1:0);
+}
+function buildCubeData() {
+  const max = N - 1;
+  const list = [];
+  for (let x=-max; x<=max; x+=2)
+    for (let y=-max; y<=max; y+=2)
+      for (let z=-max; z<=max; z+=2) {
+        const colors = {};
+        for (const d of Object.keys(DIRV)) {
+          const axis = d[1], sgn = d[0]==='+'?1:-1;
+          colors[d] = faceKey(axis, sgn, {x,y,z}[axis], max);
+        }
+        list.push({x, y, z, q: new THREE.Quaternion(), colors, mesh: null});
+      }
+  return list;
+}
+function layerVal(layerIdx) { return 2*layerIdx - (N-1); }
+function cubieAt(x,y,z) {
+  for (const c of cubies) {
+    if (Math.abs(c.x-x)<1e-9 && Math.abs(c.y-y)<1e-9 && Math.abs(c.z-z)<1e-9) return c;
+  }
+  return null;
+}
+function applyMoveLogical(axis, layerIdx, angleDeg) {
+  const val = layerVal(layerIdx);
+  const q = new THREE.Quaternion().setFromAxisAngle(axisVec(axis), angleDeg*Math.PI/180);
+  const ai = AXIS_IDX[axis];
+  for (const c of cubies) {
+    const coord = [c.x,c.y,c.z][ai];
+    if (Math.abs(coord-val)>1e-9) continue;
+    const v = new THREE.Vector3(c.x,c.y,c.z).applyQuaternion(q);
+    c.x = Math.round(v.x); c.y = Math.round(v.y); c.z = Math.round(v.z);
+    c.q.premultiply(q);
+  }
+}
+function netColor(face, r, c) {
+  const max = N-1;
+  let x,y,z,dir;
+  switch (face) {
+    case 'U': x=-max+2*c; y=max; z=-max+2*r; dir='+y'; break;
+    case 'D': x=-max+2*c; y=-max; z=max-2*r; dir='-y'; break;
+    case 'F': x=-max+2*c; y=max-2*r; z=max; dir='+z'; break;
+    case 'B': x=max-2*c; y=max-2*r; z=-max; dir='-z'; break;
+    case 'L': x=-max; y=max-2*r; z=-max+2*c; dir='-x'; break;
+    case 'R': x=max; y=max-2*r; z=max-2*c; dir='+x'; break;
+  }
+  const c0 = cubieAt(x,y,z);
+  if (!c0) return 'K';
+  const wd = new THREE.Vector3(...DIRV[dir]);
+  for (const ld of Object.keys(DIRV)) {
+    if (new THREE.Vector3(...DIRV[ld]).applyQuaternion(c0.q).distanceTo(wd) < 1e-6) return c0.colors[ld];
+  }
+  return 'K';
+}
+function isSolved() {
+  for (const face of FACES) {
+    const ref = netColor(face,0,0);
+    for (let r=0;r<N;r++) for (let c=0;c<N;c++) if (netColor(face,r,c)!==ref) return false;
+  }
+  return true;
+}
+
+/* ---------- 3D 渲染 ---------- */
+let renderer, scene, camera, controls, cubeGroup, selBox, selEdge;
+let resizeObserver = null;
+let winResize3d = null, winResizeNet = null;
+
+function init3D() {
+  renderer = new THREE.WebGLRenderer({canvas: canvasEl, antialias:true, alpha:true});
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+
+  scene = new THREE.Scene();
+  camera = new THREE.PerspectiveCamera(40, 1, 0.1, 200);
+
+  scene.add(new THREE.AmbientLight(0xffffff, 0.88));
+  const key = new THREE.DirectionalLight(0xffffff, 1.2);
+  key.position.set(5, 9, 7);
+  scene.add(key);
+  const fill = new THREE.DirectionalLight(0xffffff, 0.45);
+  fill.position.set(-7, -3, -5);
+  scene.add(fill);
+  const rim = new THREE.DirectionalLight(0xffffff, 0.4);
+  rim.position.set(-3, 5, -8);
+  scene.add(rim);
+
+  cubeGroup = new THREE.Group();
+  scene.add(cubeGroup);
+
+  controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.12;
+  controls.enablePan = false;
+  controls.minDistance = N*1.2 + 1.5;
+  controls.maxDistance = N*4 + 8;
+
+  const boxGeo = new THREE.BoxGeometry(1,1,1);
+  selBox = new THREE.Mesh(boxGeo, new THREE.MeshBasicMaterial({
+    color: 0x5cd6ff, transparent:true, opacity:0.16, depthWrite:false
+  }));
+  selBox.visible = false;
+  scene.add(selBox);
+  selEdge = new THREE.LineSegments(
+    new THREE.EdgesGeometry(boxGeo),
+    new THREE.LineBasicMaterial({color:0x66e0ff, transparent:true, opacity:1.0})
+  );
+  selEdge.visible = false;
+  scene.add(selEdge);
+
+  resize();
+  winResize3d = () => resize();
+  window.addEventListener('resize', winResize3d);
+  resizeObserver = new ResizeObserver(resize);
+  resizeObserver.observe(stageEl);
+  animate();
+}
+function resize() {
+  const w = stageEl.clientWidth, h = Math.max(stageEl.clientHeight, 260);
+  renderer.setSize(w, h, false);
+  camera.aspect = w/h;
+  camera.updateProjectionMatrix();
+}
+function frameCamera() {
+  const d = N*1.7 + 3.4;
+  camera.position.set(d*0.72, d*0.6, d*0.86);
+  camera.lookAt(0,0,0);
+  controls.target.set(0,0,0);
+  controls.minDistance = N*1.2 + 1.5;
+  controls.maxDistance = N*4 + 8;
+  controls.update();
+}
+function mat(color) {
+  return new THREE.MeshPhongMaterial({color: new THREE.Color(color), shininess: 120, specular: 0x333333});
+}
+const matCache = {};
+function matFor(key) { return matCache[key] || (matCache[key] = mat(FACE_COLOR[key])); }
+
+function createMeshes() {
+  while (cubeGroup.children.length) {
+    const child = cubeGroup.children.pop();
+    if (child.geometry) child.geometry.dispose();
+  }
+  const geo = new THREE.BoxGeometry(0.94, 0.94, 0.94);
+  const edgeGeo = new THREE.EdgesGeometry(geo);
+  const edgeMat = new THREE.LineBasicMaterial({color:0x66e0ff, transparent:true, opacity:0.95});
+  for (const c of cubies) {
+    const order = ['+x','-x','+y','-y','+z','-z'];
+    const hasColor = order.some(d => c.colors[d] !== 'K');
+    if (!hasColor) continue;
+    const mats = order.map(d => matFor(c.colors[d]));
+    c.mesh = new THREE.Mesh(geo, mats);
+    c.mesh.position.set(c.x/2, c.y/2, c.z/2);
+    c.mesh.quaternion.copy(c.q);
+    c.edges = new THREE.LineSegments(edgeGeo, edgeMat);
+    c.edges.visible = false;
+    c.mesh.add(c.edges);
+    cubeGroup.add(c.mesh);
+  }
+}
+function syncMeshes() {
+  for (const c of cubies) {
+    if (!c.mesh) continue;
+    c.mesh.position.set(c.x/2, c.y/2, c.z/2);
+    c.mesh.quaternion.copy(c.q);
+  }
+}
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}
+
+/* ---------- 转动动画（枢轴方案） ---------- */
+let moveQueue = [];
+let busy = false;
+let curPivot = null;
+let curLayer = null;
+let curMove = null;
+let rafId = null;
+
+function easeInOut(t) { return t<0.5 ? 4*t*t*t : 1-Math.pow(-2*t+2,3)/2; }
+
+function animateMove(axis, layerIdx, angleDeg, speed, done) {
+  const q = new THREE.Quaternion().setFromAxisAngle(axisVec(axis), angleDeg*Math.PI/180);
+  const val = layerVal(layerIdx);
+  const pivot = new THREE.Group();
+  cubeGroup.add(pivot);
+  curPivot = pivot;
+  curLayer = [];
+  curMove = {axis, layerIdx, angleDeg};
+  for (const c of cubies) {
+    if (!c.mesh) continue;
+    if (Math.abs([c.x,c.y,c.z][AXIS_IDX[axis]] - val) > 1e-9) continue;
+    pivot.attach(c.mesh);
+    curLayer.push(c);
+  }
+  const q0 = new THREE.Quaternion();
+  const t0 = performance.now();
+  function step(now) {
+    if (curPivot !== pivot) return;
+    let t = Math.min((now - t0) / speed, 1);
+    pivot.quaternion.copy(q0).slerp(q, easeInOut(t));
+    if (t < 1) {
+      rafId = requestAnimationFrame(step);
+    } else {
+      pivot.quaternion.copy(q);
+      pivot.updateMatrixWorld(true);
+      for (const c of curLayer) cubeGroup.attach(c.mesh);
+      cubeGroup.remove(pivot);
+      curPivot = null; curLayer = null; curMove = null;
+      applyMoveLogical(axis, layerIdx, angleDeg);
+      syncMeshes();
+      afterMove();
+      if (done) done();
+    }
+  }
+  rafId = requestAnimationFrame(step);
+}
+function requestMove(axis, layerIdx, angleDeg, speed) {
+  moveQueue.push({axis, layerIdx, angleDeg, speed: speed || 210});
+  pump();
+}
+function pump() {
+  if (busy || moveQueue.length === 0) return;
+  busy = true;
+  const m = moveQueue.shift();
+  animateMove(m.axis, m.layerIdx, m.angleDeg, m.speed, () => { busy = false; pump(); });
+}
+function afterMove() {
+  if (skipMoves > 0) skipMoves--;
+  else {
+    moveCount++;
+    $('#moveCount').textContent = moveCount;
+  }
+  drawNet();
+  updateHighlight();
+  updateSolved();
+}
+
+/* ---------- 2D 展开图渲染 ---------- */
+const NET_LAYOUT = {U:[1,0], L:[0,1], F:[1,1], R:[2,1], B:[3,1], D:[1,2]};
+
+function drawGraphBg() {
+  let s = '';
+  const w = 640, h = 360;
+  for (let i=0;i<6;i++) s += `<circle cx="${w/2}" cy="${h/2}" r="${26+i*44}"></circle>`;
+  const nodes = [];
+  for (let i=0;i<14;i++) {
+    const ang = i/14*Math.PI*2;
+    const r = 70 + (i%5)*48;
+    const x = w/2 + Math.cos(ang)*r, y = h/2 + Math.sin(ang)*r*0.8;
+    nodes.push({x,y});
+    const cols = ['#35c56c','#3a7bff','#ff5a5a','#ffd23f','#ff9432','#5cd6ff'];
+    s += `<circle class="node" cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${cols[i%6]}"></circle>`;
+  }
+  for (let i=0;i<nodes.length;i++) {
+    const j = (i+3)%nodes.length;
+    s += `<line class="link" x1="${nodes[i].x.toFixed(1)}" y1="${nodes[i].y.toFixed(1)}" x2="${nodes[j].x.toFixed(1)}" y2="${nodes[j].y.toFixed(1)}"></line>`;
+  }
+  graphSvg.innerHTML = s;
+  graphSvg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+}
+
+function drawNet() {
+  const max = N-1;
+  const stageElN = netSvg.parentElement;
+  const availW = stageElN.clientWidth || 560;
+  const budgetH = Math.max(170, Math.min(440, Math.round(window.innerHeight * 0.34)));
+  const cell = Math.max(8, Math.min(
+    Math.floor((availW - 18) / (4*N)),
+    Math.floor((budgetH - 18) / (3*N))
+  ));
+  const pad = 9;
+  const W = pad*2 + 4*N*cell;
+  const H = pad*2 + 3*N*cell;
+  netSvg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+  netSvg.setAttribute('width', W);
+  netSvg.setAttribute('height', H);
+  netSvg.style.width = 'auto';
+  netSvg.style.height = 'auto';
+  netSvg.style.maxWidth = '100%';
+  netSvg.style.margin = '0 auto';
+
+  let s = '';
+  for (const face of FACES) {
+    const [gx, gy] = NET_LAYOUT[face];
+    const x0 = pad + gx*N*cell, y0 = pad + gy*N*cell;
+    s += `<rect x="${x0}" y="${y0}" width="${N*cell}" height="${N*cell}" rx="${Math.min(6,cell*0.35)}" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.08)"></rect>`;
+    for (let r=0;r<N;r++) for (let c=0;c<N;c++) {
+      const key = netColor(face, r, c);
+      const x = x0 + c*cell, y = y0 + r*cell;
+      let cls = 'cell';
+      if (selected && isInLayer(cubieOf(face, r, c), selected.axis, selected.layerIdx)) cls += ' hot';
+      const rr = Math.max(0.5, cell*0.16);
+      s += `<rect class="${cls}" x="${x+0.6}" y="${y+0.6}" width="${cell-1.2}" height="${cell-1.2}" rx="${rr}" fill="${FACE_COLOR[key]}"></rect>`;
+    }
+    const hot = selected && selected.axis === FACE_AXIS[face] &&
+                selected.layerIdx === (FACE_AXIS[face]==='y' ? (face==='U'?max:0) : FACE_AXIS[face]==='x' ? (face==='R'?max:0) : (face==='F'?max:0));
+    s += `<text class="face-label${hot?' hot':''}" x="${x0+4}" y="${y0+13}" font-size="11">${face}</text>`;
+  }
+  netSvg.innerHTML = s;
+}
+function cubieOf(face, r, c) {
+  const max = N-1;
+  let x,y,z;
+  switch (face) {
+    case 'U': x=-max+2*c; y=max; z=-max+2*r; break;
+    case 'D': x=-max+2*c; y=-max; z=max-2*r; break;
+    case 'F': x=-max+2*c; y=max-2*r; z=max; break;
+    case 'B': x=max-2*c; y=max-2*r; z=-max; break;
+    case 'L': x=-max; y=max-2*r; z=-max+2*c; break;
+    case 'R': x=max; y=max-2*r; z=max-2*c; break;
+  }
+  return {x,y,z};
+}
+function isInLayer(cube, axis, layerIdx) {
+  if (!cube) return false;
+  return Math.abs(cube[axis] - layerVal(layerIdx)) < 1e-9;
+}
+
+function bindNetSvg() {
+  netSvg.addEventListener('pointerdown', (e) => {
+    const rect = netSvg.getBoundingClientRect();
+    const vb = netSvg.viewBox.baseVal;
+    const px = (e.clientX - rect.left) / rect.width * vb.width;
+    const py = (e.clientY - rect.top) / rect.height * vb.height;
+    const pad = 9;
+    const max = N-1;
+    const cell = (vb.width - pad*2) / (4*N);
+    const gx = Math.floor((px - pad) / (N*cell));
+    const gy = Math.floor((py - pad) / (N*cell));
+    let face = null;
+    for (const f of FACES) {
+      const [fx, fy] = NET_LAYOUT[f];
+      if (fx===gx && fy===gy) { face = f; break; }
+    }
+    if (!face) return;
+    const c = Math.floor((px - pad - gx*N*cell) / cell);
+    const r = Math.floor((py - pad - gy*N*cell) / cell);
+    if (c<0||c>=N||r<0||r>=N) return;
+    if (e.button === 2) {
+      const cub = cubieOf(face, r, c);
+      const layerIdx = (cub.y + max)/2;
+      selectLayer('y', layerIdx, findFace('y', layerIdx) || undefined);
+      return;
+    }
+    const axis = FACE_AXIS[face];
+    const layerIdx = axis==='y' ? (face==='U'?max:0) : axis==='x' ? (face==='R'?max:0) : (face==='F'?max:0);
+    selectLayer(axis, layerIdx, face);
+  });
+  netSvg.addEventListener('contextmenu', (e) => e.preventDefault());
+}
+
+/* ---------- 选择与联动高亮 ---------- */
+function selectLayer(axis, layerIdx, faceName) {
+  selected = {axis, layerIdx};
+  layerMem[axis] = layerIdx;
+  if (faceName) {
+    $all('#faceBtns .chip').forEach(b => b.classList.toggle('active', b.dataset.face === faceName));
+  }
+  uiAxis = axis;
+  $all('#axisBtns .chip').forEach(b => b.classList.toggle('active', b.dataset.axis===axis));
+  rebuildLayerBtns();
+  updateHighlight();
+  updateSelInfo();
+}
+function updateSelInfo() {
+  const el = $('#selInfo');
+  if (!selected) { el.innerHTML = '未选择 · 点击魔方或展开图选层'; return; }
+  const {axis, layerIdx} = selected;
+  const face = findFace(axis, layerIdx);
+  el.innerHTML = face
+    ? `选中：<b>${face}</b>（${FACE_CN[face]}）· ${axis.toUpperCase()} 第${layerIdx+1}/${N} 层`
+    : `选中：<b>${axis.toUpperCase()}</b> 第${layerIdx+1}/${N} 层（中层）`
+}
+function findFace(axis, layerIdx) {
+  const max = N-1;
+  if (axis==='y') return layerIdx===max?'U':layerIdx===0?'D':null;
+  if (axis==='x') return layerIdx===max?'R':layerIdx===0?'L':null;
+  return layerIdx===max?'F':layerIdx===0?'B':null;
+}
+function updateHighlight() {
+  if (!selected) {
+    selBox.visible = false; selEdge.visible = false;
+    for (const c of cubies) if (c.edges) c.edges.visible = false;
+    drawNet();
+    return;
+  }
+  const {axis, layerIdx} = selected;
+  const max = N-1;
+  selBox.visible = true; selEdge.visible = true;
+  const sx = axis==='x'?1.0:N, sy = axis==='y'?1.0:N, sz = axis==='z'?1.0:N;
+  selBox.scale.set(sx, sy, sz);
+  selEdge.scale.set(sx, sy, sz);
+  const pos = layerVal(layerIdx)/2;
+  selBox.position.set(axis==='x'?pos:0, axis==='y'?pos:0, axis==='z'?pos:0);
+  selEdge.position.copy(selBox.position);
+  const val = layerVal(layerIdx);
+  const ai = AXIS_IDX[axis];
+  for (const c of cubies) {
+    if (!c.mesh || !c.edges) continue;
+    c.edges.visible = Math.abs([c.x,c.y,c.z][ai] - val) < 1e-9;
+  }
+  drawNet();
+}
+function rebuildLayerBtns() {
+  const wrap = $('#layerBtns');
+  let s = '';
+  for (let i=0;i<N;i++) {
+    const active = selected && selected.axis===uiAxis && selected.layerIdx===i;
+    s += `<button class="chip${active?' active':''}" data-layer="${i}">${i+1}</button>`;
+  }
+  wrap.innerHTML = s;
+  wrap.querySelectorAll('.chip').forEach(b => {
+    b.addEventListener('click', () => selectLayer(uiAxis, +b.dataset.layer));
+  });
+}
+
+/* ---------- 3D 交互：点击选层 / 拖拽转动 ---------- */
+const raycaster = new THREE.Raycaster();
+const ndc = new THREE.Vector2();
+let drag = null;
+
+function pickPointer(e) {
+  const rect = canvasEl.getBoundingClientRect();
+  ndc.x = ((e.clientX-rect.left)/rect.width)*2-1;
+  ndc.y = -((e.clientY-rect.top)/rect.height)*2+1;
+  raycaster.setFromCamera(ndc, camera);
+  const hits = raycaster.intersectObjects(cubeGroup.children, false);
+  if (hits.length===0) return null;
+  const hit = hits[0];
+  const mesh = hit.object;
+  const n = hit.face.normal.clone().applyQuaternion(mesh.quaternion).normalize();
+  const axis = Math.abs(n.x)>=Math.abs(n.y) && Math.abs(n.x)>=Math.abs(n.z) ? 'x'
+             : Math.abs(n.y)>=Math.abs(n.z) ? 'y' : 'z';
+  return {mesh, cubie: cubieOfMesh(mesh), axis, normal: n, point: hit.point};
+}
+function cubieOfMesh(mesh) {
+  for (const c of cubies) if (c.mesh===mesh) return c;
+  return null;
+}
+function bind3DCanvas() {
+  canvasEl.addEventListener('pointerdown', (e) => {
+    try { canvasEl.setPointerCapture(e.pointerId); } catch (err) {}
+    const info = pickPointer(e);
+    if (!info) { drag = {orbit:true}; return; }
+    if (e.button === 2) {
+      const max = N-1;
+      const layerIdx = (info.cubie.y + max)/2;
+      selectLayer('y', layerIdx, findFace('y', layerIdx) || undefined);
+      return;
+    }
+    drag = {orbit:false, info, startX:e.clientX, startY:e.clientY, moved:false, triggered:false};
+    controls.enabled = false;
+  });
+  canvasEl.addEventListener('contextmenu', (e) => e.preventDefault());
+  canvasEl.addEventListener('pointermove', (e) => {
+    if (!drag || drag.orbit) return;
+    const dx = e.clientX - drag.startX, dy = e.clientY - drag.startY;
+    if (!drag.moved && Math.hypot(dx,dy) > 9) {
+      drag.moved = true;
+      doDragRotate(drag.info, dx, dy);
+    }
+  });
+  canvasEl.addEventListener('pointerup', endDrag);
+  canvasEl.addEventListener('pointercancel', endDrag);
+  canvasEl.addEventListener('pointerleave', (e) => { if (drag && drag.orbit) drag=null; });
+}
+function doDragRotate(info, dx, dy) {
+  const c = info.cubie;
+  const p = new THREE.Vector3(c.x, c.y, c.z);
+  if (selected && isInLayer(c, selected.axis, selected.layerIdx)) {
+    const ang = angleForAxis(selected.axis, c, dx, dy);
+    if (ang !== null) {
+      requestMove(selected.axis, selected.layerIdx, ang, 230);
+      return;
+    }
+  }
+  let bestAxis = null, bestAngle = 0, bestScore = -1;
+  for (const a of AXES) {
+    if (a === info.axis) continue;
+    const av = axisVec(a);
+    const t = new THREE.Vector3().crossVectors(av, p);
+    if (t.lengthSq() < 1e-6) continue;
+    const p1 = project3D(p.clone().add(t).multiplyScalar(1.0));
+    const p0 = project3D(p.clone().multiplyScalar(1.0));
+    const sx = p1.x - p0.x, sy = -(p1.y - p0.y);
+    const score = sx*dx + sy*dy;
+    if (Math.abs(score) > bestScore) {
+      bestScore = Math.abs(score);
+      bestAxis = a;
+      bestAngle = score > 0 ? 90 : -90;
+    }
+  }
+  if (!bestAxis) return;
+  const max = N-1;
+  const coord = [c.x,c.y,c.z][AXIS_IDX[bestAxis]];
+  const layerIdx = (coord + max)/2;
+  requestMove(bestAxis, layerIdx, bestAngle, 230);
+  selectLayer(bestAxis, layerIdx);
+}
+function angleForAxis(a, c, dx, dy) {
+  const p = new THREE.Vector3(c.x, c.y, c.z);
+  const t = new THREE.Vector3().crossVectors(axisVec(a), p);
+  if (t.lengthSq() < 1e-6) return null;
+  const p1 = project3D(p.clone().add(t).multiplyScalar(1.0));
+  const p0 = project3D(p.clone().multiplyScalar(1.0));
+  const sx = p1.x - p0.x, sy = -(p1.y - p0.y);
+  const score = sx*dx + sy*dy;
+  if (Math.abs(score) < 1e-3) return null;
+  return score > 0 ? 90 : -90;
+}
+function project3D(v3) {
+  const v = v3.clone().project(camera);
+  return {x: v.x, y: v.y};
+}
+function endDrag(e) {
+  if (drag && !drag.orbit) {
+    if (!drag.moved) {
+      const info = drag.info;
+      const max = N-1;
+      const coord = [info.cubie.x, info.cubie.y, info.cubie.z][AXIS_IDX[info.axis]];
+      const layerIdx = (coord + max)/2;
+      selectLayer(info.axis, layerIdx, findFace(info.axis, layerIdx)||undefined);
+    }
+    controls.enabled = true;
+  }
+  drag = null;
+}
+
+/* ---------- 控制面板 ---------- */
+function bindControls() {
+  $all('#faceBtns .chip').forEach(b => {
+    b.addEventListener('click', () => {
+      const f = b.dataset.face;
+      const max = N-1;
+      const axis = FACE_AXIS[f];
+      const layerIdx = axis==='y' ? (f==='U'?max:0) : axis==='x' ? (f==='R'?max:0) : (f==='F'?max:0);
+      selectLayer(axis, layerIdx, f);
+    });
+  });
+  $all('#axisBtns .chip').forEach(b => {
+    b.addEventListener('click', () => {
+      uiAxis = b.dataset.axis;
+      const layerIdx = selected && selected.axis===uiAxis ? selected.layerIdx : N-1;
+      selectLayer(uiAxis, layerIdx);
+    });
+  });
+  $('#cwBtn').addEventListener('click', () => rotateSelected(1));
+  $('#ccwBtn').addEventListener('click', () => rotateSelected(-1));
+  $('#scrambleBtn').addEventListener('click', () => {
+    const moves = Math.min(44, N*6);
+    scrambleCount = moves;
+    moveCount = 0;
+    skipMoves = moves;
+    $('#scrambleCount').textContent = moves;
+    $('#moveCount').textContent = '0';
+    for (let i=0;i<moves;i++) {
+      const axis = AXES[(Math.random()*3)|0];
+      const layerIdx = (Math.random()*N)|0;
+      const angle = Math.random()<0.5 ? 90 : -90;
+      moveQueue.push({axis, layerIdx, angleDeg:angle, speed:65});
+    }
+    pump();
+  });
+  $('#resetBtn').addEventListener('click', resetCube);
+  $all('.size-switch button').forEach(b => {
+    b.addEventListener('click', () => {
+      const sz = +b.dataset.size;
+      if (sz === N) return;
+      N = sz;
+      $all('.size-switch button').forEach(x => x.classList.toggle('active', +x.dataset.size===N));
+      resetCube();
+      if (formulaModal && !formulaModal.hidden) buildFormulaPanel();
+    });
+  });
+}
+function rotateSelected(dir) {
+  if (!selected) return;
+  const {axis, layerIdx} = selected;
+  const face = findFace(axis, layerIdx);
+  const angle = face ? FACE_ANGLE[face]*dir : -90*dir;
+  requestMove(axis, layerIdx, angle, 220);
+}
+
+/* ---------- 键盘控制（仅在 overlay 打开时响应） ---------- */
+const KEY_AXIS_CYCLE = [['y','横'], ['x','纵'], ['z','面']];
+let axisModeIdx = 0;
+function cycleAxisMode() {
+  axisModeIdx = (axisModeIdx + 1) % KEY_AXIS_CYCLE.length;
+  const [axis] = KEY_AXIS_CYCLE[axisModeIdx];
+  const max = N-1;
+  const nIdx = selected ? Math.min(selected.layerIdx, max) : max;
+  selectLayer(axis, nIdx, findFace(axis, nIdx) || undefined);
+}
+function keydownHandler(e) {
+  if (!rootEl || !rootEl.classList.contains('visible')) return;
+  const t = e.target;
+  if (t && (t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable)) return;
+  if ((e.ctrlKey && e.key !== 'Control') || e.metaKey || e.altKey) return;
+  const k = e.key.toLowerCase();
+  const max = N-1;
+  const dm = /^(?:Digit|Numpad)([0-9])$/.exec(e.code);
+  if (dm) {
+    const n = +dm[1];
+    if (n >= 1 && n <= N) {
+      const axis = selected ? selected.axis : uiAxis;
+      selectLayer(axis, n - 1, findFace(axis, n - 1) || undefined);
+    }
+    e.preventDefault();
+    return;
+  }
+  const move = (axis, delta) => {
+    const base = layerMem[axis] !== undefined ? layerMem[axis] : (delta>0 ? max : 0);
+    const nIdx = Math.max(0, Math.min(max, base + delta));
+    selectLayer(axis, nIdx, findFace(axis, nIdx) || undefined);
+  };
+  switch (k) {
+    case 'w': move('y', +1); break;
+    case 's': move('y', -1); break;
+    case 'a': move('x', -1); break;
+    case 'd': move('x', +1); break;
+    case 'q': move('z', +1); break;
+    case 'e': move('z', -1); break;
+    case 'r': cycleAxisMode(); break;
+    case 'control': rotateSelected(-1); break;
+    case ' ': rotateSelected(1); break;
+    default: return;
+  }
+  e.preventDefault();
+}
+
+/* ---------- 打乱 / 还原 / 阶数 ---------- */
+function resetCube() {
+  if (curPivot) {
+    cancelAnimationFrame(rafId);
+    for (const c of curLayer) cubeGroup.attach(c.mesh);
+    cubeGroup.remove(curPivot);
+    curPivot = null; curLayer = null; curMove = null;
+    syncMeshes();
+  }
+  moveQueue.length = 0;
+  busy = false;
+  moveCount = 0;
+  scrambleCount = 0;
+  $('#moveCount').textContent = '0';
+  $('#scrambleCount').textContent = '0';
+  selected = null;
+  $all('#faceBtns .chip').forEach(b => b.classList.remove('active'));
+  buildScene();
+}
+function buildScene() {
+  cubies = buildCubeData();
+  createMeshes();
+  syncMeshes();
+  frameCamera();
+  rebuildLayerBtns();
+  drawNet();
+  updateHighlight();
+  updateSelInfo();
+  updateSolved();
+}
+function updateSolved() {
+  const el = $('#solvedBadge');
+  el.classList.toggle('show', isSolved());
+}
+
+/* ---------- 复原公式面板（2/4/5/高阶按阶数） ---------- */
+const PANEL_2 = {
+  tabs: '<button class="tab active" data-tab="o2">2 阶 · 面先法</button>',
+  body: `<div class="tab-pane active" id="pane-o2">
+  <div class="fc-note-only">面先法（ORTEGA）：先拼任意一面 → OLL 翻好顶面 → PBL 同时调整上下两层。2 阶没有中心块与棱块，公式比 3 阶短得多</div>
+  <div class="sec-label">1 · 底面</div>
+  <div class="fc"><span class="fc-name">拼底面</span><span class="fc-note">无固定公式：先拼出任意一面（同色即可），侧面颜色暂不需对齐</span></div>
+  <div class="sec-label">2 · 顶面翻色 OLL</div>
+  <div class="fc"><span class="fc-name">Sune 小鱼</span><div class="fc-alg" data-alg="R U R' U R U2 R'"><code>R U R' U R U2 R'</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">Anti-Sune</span><div class="fc-alg" data-alg="R U2 R' U' R U' R'"><code>R U2 R' U' R U' R'</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">十字型</span><div class="fc-alg" data-alg="F R U R' U' F'"><code>F R U R' U' F'</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">T 型</span><div class="fc-alg" data-alg="R U R' U' R' F R F'"><code>R U R' U' R' F R F'</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">双头灯</span><div class="fc-alg" data-alg="R U R' U R U' R' U R U2 R'"><code>R U R' U R U' R' U R U2 R'</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">蝴蝶结</span><div class="fc-alg" data-alg="F R' F' R U R' F'"><code>F R' F' R U R' F'</code><span class="copy-tip"></span></div></div>
+  <div class="sec-label">3 · 两层调整 PBL</div>
+  <div class="fc"><span class="fc-name">对角换 Y</span><div class="fc-alg" data-alg="F R U' R' U' R U R' F' R U R' U' R' F R F'"><code>F R U' R' U' R U R' F' R U R' U' R' F R F'</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">上下对角</span><div class="fc-alg" data-alg="R2 F2 R2"><code>R2 F2 R2</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">前棱互换</span><div class="fc-alg" data-alg="R2 U' R2 U2' R2 U' R2"><code>R2 U' R2 U2' R2 U' R2</code><span class="copy-tip"></span></div></div>
+  <div class="fc"><span class="fc-name">后棱互换</span><div class="fc-alg" data-alg="R2 U R2 U2 F2 U' F2"><code>R2 U R2 U2 F2 U' F2</code><span class="copy-tip"></span></div></div>
+</div>`
+};
+const PANEL_4 = {
+  tabs: '<button class="tab active" data-tab="o4">4 阶 · 降阶法</button>',
+  body: `<div class="tab-pane active" id="pane-o4">
+  <div class="fc-note-only">4 阶降阶法：合并 2×2 中心块 → 合并棱 → 按 3 阶还原 → 处理特殊情况（奇偶校验）。降阶完成后可能出现 3 阶无法还原的情况，用下面的特殊公式</div>
+  <div class="sec-label">1 · 合并中心</div>
+  <div class="fc"><span class="fc-name">合并中心块</span><span class="fc-note">无固定公式：用「Rw U Rw'」类手法把同色中心小块并成 2×2</span></div>
+  <div class="sec-label">2 · 合并棱</div>
+  <div class="fc"><span class="fc-name">最后两棱</span><div class="fc-alg" data-alg="Uw' R U R' F R' F' R Uw"><code>Uw' R U R' F R' F' R Uw</code><span class="copy-tip"></span></div><span class="fc-note">只剩最后两组棱未合并时使用</span></div>
+  <div class="sec-label">3 · 特殊情况（3 阶无法还原时）</div>
+  <div class="fc"><span class="fc-name">OLL 翻单棱</span><div class="fc-alg" data-alg="Rw U2 x Rw U2 Rw U2 Rw' U2 Lw U2 Rw' U2 Rw U2 Rw' U2 Rw'"><code>Rw U2 x Rw U2 Rw U2 Rw' U2 Lw U2 Rw' U2 Rw U2 Rw' U2 Rw'</code><span class="copy-tip"></span></div><span class="fc-note">顶面出现奇数条黄棱（单棱翻）时使用</span></div>
+  <div class="fc"><span class="fc-name">PLL 对棱换</span><div class="fc-alg" data-alg="Rw2 R2 U2 Rw2 R2 Uw2 Rw2 R2 Uw2"><code>Rw2 R2 U2 Rw2 R2 Uw2 Rw2 R2 Uw2</code><span class="copy-tip"></span></div><span class="fc-note">顶层只剩一对棱需要互换时使用</span></div>
+  <div class="fc"><span class="fc-name">邻棱换</span><span class="fc-note">先做一次「PLL 对棱换」公式，再按 3 阶三棱换公式处理</span></div>
+</div>`
+};
+const PANEL_5 = {
+  tabs: '<button class="tab active" data-tab="o5">5 阶 · 降阶法</button>',
+  body: `<div class="tab-pane active" id="pane-o5">
+  <div class="fc-note-only">5 阶降阶法：合并 3×3 中心块 → 合并棱（三棱一组）→ 按 3 阶还原。5 阶是奇数阶，没有 OLL/PLL 奇偶校验，但最后两棱有专门公式</div>
+  <div class="sec-label">1 · 合并中心</div>
+  <div class="fc"><span class="fc-name">合并中心块</span><span class="fc-note">无固定公式：先拼中心 3×3（先中心条再补角），手法与 4 阶类似</span></div>
+  <div class="sec-label">2 · 合并棱</div>
+  <div class="fc"><span class="fc-name">对棱公式</span><div class="fc-alg" data-alg="Rw2 F2 U2 Rw2 U2 F2 Rw2"><code>Rw2 F2 U2 Rw2 U2 F2 Rw2</code><span class="copy-tip"></span></div></div>
+  <div class="sec-label">3 · 最后两棱（特殊情况）</div>
+  <div class="fc"><span class="fc-name">最后两棱</span><div class="fc-alg" data-alg="Rw2 B2 U2 Lw U2 Rw' U2 Rw U2 F2 Rw F2 Lw' B2 Rw2"><code>Rw2 B2 U2 Lw U2 Rw' U2 Rw U2 F2 Rw F2 Lw' B2 Rw2</code><span class="copy-tip"></span></div><span class="fc-note">最后两组棱色相不正确时使用</span></div>
+  <div class="fc"><span class="fc-name">单翻内棱块</span><div class="fc-alg" data-alg="Rw U2 x Rw U2 Rw U2 Rw' U2 Lw U2 3Rw' U2 Rw U2 Rw' U2 Rw'"><code>Rw U2 x Rw U2 Rw U2 Rw' U2 Lw U2 3Rw' U2 Rw U2 Rw' U2 Rw'</code><span class="copy-tip"></span></div><span class="fc-note">进阶：内层单棱翻转的特殊情况</span></div>
+</div>`
+};
+const PANEL_HIGH = {
+  tabs: '<button class="tab active" data-tab="oh">6/7 阶 · 降阶法</button>',
+  body: `<div class="tab-pane active" id="pane-oh">
+  <div class="fc-note-only">6 阶（偶数）与 7 阶（奇数）都用降阶法：合并中心块 → 合并棱 → 按 3 阶还原。核心思想与 4/5 阶一致，只是中心更大、棱更多</div>
+  <div class="sec-label">1 · 合并中心</div>
+  <div class="fc"><span class="fc-name">合并中心块</span><span class="fc-note">无固定公式：一行一行拼中心（6 阶 4×4、7 阶 5×5），再补中心角</span></div>
+  <div class="sec-label">2 · 合并棱</div>
+  <div class="fc"><span class="fc-name">并棱手法</span><span class="fc-note">与 4/5 阶相同：用「Uw' R U R' F R' F' R Uw」类公式逐组拼棱</span></div>
+  <div class="sec-label">3 · 特殊情况</div>
+  <div class="fc"><span class="fc-name">6 阶（偶数）奇偶校验</span><span class="fc-note">OLL 翻棱 / PLL 对棱换公式与 4 阶相同，直接套用 4 阶面板里的 OLL 翻单棱、PLL 对棱换公式</span></div>
+  <div class="fc"><span class="fc-name">7 阶（奇数）</span><span class="fc-note">最后两棱特殊情况与 5 阶相同，套用 5 阶面板的最后两棱 / 单翻内棱公式</span></div>
+</div>`
+};
+
+function buildFormulaPanel() {
+  const tabsEl = $('#formulaTabs');
+  const bodyEl = $('.modal-body');
+  if (N === 3) {
+    tabsEl.innerHTML = formulaTabsDefault;
+    bodyEl.innerHTML = formulaBodyDefault;
+    renderFormulaCases();
+  }
+  else if (N === 2) { tabsEl.innerHTML = PANEL_2.tabs; bodyEl.innerHTML = PANEL_2.body; }
+  else if (N === 4) { tabsEl.innerHTML = PANEL_4.tabs; bodyEl.innerHTML = PANEL_4.body; }
+  else if (N === 5) { tabsEl.innerHTML = PANEL_5.tabs; bodyEl.innerHTML = PANEL_5.body; }
+  else { tabsEl.innerHTML = PANEL_HIGH.tabs; bodyEl.innerHTML = PANEL_HIGH.body; }
+}
+let formulaTabsDefault = '', formulaBodyDefault = '';
+
+function bindFormulaModal() {
+  formulaModal = $('#formulaModal');
+  formulaTabs = $('#formulaTabs');
+  formulaBody = $('.modal-body');
+  formulaTabsDefault = formulaTabs.innerHTML;
+  formulaBodyDefault = formulaBody.innerHTML;
+  $('#formulaBtn').addEventListener('click', () => { buildFormulaPanel(); formulaModal.hidden = false; });
+  $('#formulaClose').addEventListener('click', () => { formulaModal.hidden = true; });
+  formulaModal.addEventListener('click', (e) => { if (e.target === formulaModal) formulaModal.hidden = true; });
+  formulaTabs.addEventListener('click', (e) => {
+    const tab = e.target.closest('.tab');
+    if (!tab) return;
+    $all('#formulaTabs .tab').forEach(t => t.classList.toggle('active', t === tab));
+    $all('.tab-pane').forEach(p => p.classList.toggle('active', p.id === 'pane-' + tab.dataset.tab));
+  });
+  formulaBody.addEventListener('click', (e) => {
+    const el = e.target.closest('.fc-alg');
+    if (!el) return;
+    const alg = el.dataset.alg;
+    const tip = el.querySelector('.copy-tip');
+    copyTextToClipboard(alg);
+    if (tip) { tip.textContent = '✓ 已复制'; setTimeout(() => { tip.textContent = ''; }, 1200); }
+  });
+}
+function escFormulaHandler(e) {
+  if (formulaModal && !formulaModal.hidden && e.key === 'Escape') {
+    formulaModal.hidden = true;
+  }
+}
+function copyTextToClipboard(t) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(t).catch(() => legacyCopy(t));
+  } else {
+    legacyCopy(t);
+  }
+}
+function legacyCopy(t) {
+  const ta = document.createElement('textarea');
+  ta.value = t;
+  ta.style.position = 'fixed'; ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  ta.select();
+  try { document.execCommand('copy'); } catch (e) {}
+  document.body.removeChild(ta);
+}
+
+/* ---------- 公式情况图（静态渲染，不影响正在复原的魔方） ---------- */
+function parseWCA(alg) {
+  const out = [];
+  let s = alg.replace(/\s+/g, '');
+  let i = 0;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === '(') {
+      let depth = 1, j = i + 1;
+      while (j < s.length && depth > 0) {
+        if (s[j] === '(') depth++;
+        else if (s[j] === ')') depth--;
+        if (depth === 0) break;
+        j++;
+      }
+      const inner = parseWCA(s.slice(i + 1, j));
+      let rep = 1;
+      if (s[j + 1] === '2') { rep = 2; j++; }
+      for (let r = 0; r < rep; r++) for (const m of inner) out.push(m);
+      i = j + 1;
+    } else if (/[RLUDFBMrlufb]/.test(c)) {
+      let j = i + 1;
+      let prime = false, dbl = false;
+      if (s[j] === "'") { prime = true; j++; }
+      if (s[j] === '2') { dbl = true; j++; }
+      out.push({face: c, prime, dbl});
+      i = j;
+    } else { i++; }
+  }
+  return out;
+}
+function wcaToMoves(list) {
+  const max = 2, mid = 1;
+  const moves = [];
+  const add = (axis, layerIdx, ang, dir, mult) => {
+    const a = (ang * dir * mult) % 360;
+    if (a !== 0) moves.push({axis, layerIdx, angleDeg: a});
+  };
+  for (const m of list) {
+    const dir = m.prime ? -1 : 1;
+    const mult = m.dbl ? 2 : 1;
+    switch (m.face) {
+      case 'R': add('x', max, -90, dir, mult); break;
+      case 'L': add('x', 0, 90, dir, mult); break;
+      case 'U': add('y', max, -90, dir, mult); break;
+      case 'D': add('y', 0, 90, dir, mult); break;
+      case 'F': add('z', max, -90, dir, mult); break;
+      case 'B': add('z', 0, 90, dir, mult); break;
+      case 'M': add('x', mid, 90, dir, mult); break;
+      case 'r': add('x', max, -90, dir, mult); add('x', mid, -90, dir, mult); break;
+      case 'f': add('z', max, -90, dir, mult); add('z', mid, -90, dir, mult); break;
+      default: return null;
+    }
+  }
+  return moves;
+}
+function freshCube3() {
+  const max = 2;
+  const list = [];
+  for (let x = -max; x <= max; x += 2)
+    for (let y = -max; y <= max; y += 2)
+      for (let z = -max; z <= max; z += 2) {
+        const colors = {};
+        for (const d of Object.keys(DIRV)) {
+          const axis = d[1], sgn = d[0] === '+' ? 1 : -1;
+          colors[d] = faceKey(axis, sgn, {x, y, z}[axis], max);
+        }
+        list.push({x, y, z, q: new THREE.Quaternion(), colors});
+      }
+  return list;
+}
+function applyTo(list, moves) {
+  for (const m of moves) {
+    const val = 2 * m.layerIdx - 2;
+    const q = new THREE.Quaternion().setFromAxisAngle(axisVec(m.axis), m.angleDeg * Math.PI / 180);
+    const ai = AXIS_IDX[m.axis];
+    for (const c of list) {
+      const coord = [c.x, c.y, c.z][ai];
+      if (Math.abs(coord - val) > 1e-9) continue;
+      const v = new THREE.Vector3(c.x, c.y, c.z).applyQuaternion(q);
+      c.x = Math.round(v.x); c.y = Math.round(v.y); c.z = Math.round(v.z);
+      c.q.premultiply(q);
+    }
+  }
+}
+function colorOf(list, face, r, c) {
+  const max = 2;
+  let x, y, z, dir;
+  switch (face) {
+    case 'U': x = -max + 2*c; y = max; z = -max + 2*r; dir = '+y'; break;
+    case 'D': x = -max + 2*c; y = -max; z = max - 2*r; dir = '-y'; break;
+    case 'F': x = -max + 2*c; y = max - 2*r; z = max; dir = '+z'; break;
+    case 'B': x = max - 2*c; y = max - 2*r; z = -max; dir = '-z'; break;
+    case 'L': x = -max; y = max - 2*r; z = -max + 2*c; dir = '-x'; break;
+    case 'R': x = max; y = max - 2*r; z = max - 2*c; dir = '+x'; break;
+  }
+  let c0 = null;
+  for (const cc of list) if (Math.abs(cc.x - x) < 1e-9 && Math.abs(cc.y - y) < 1e-9 && Math.abs(cc.z - z) < 1e-9) { c0 = cc; break; }
+  if (!c0) return 'K';
+  const wd = new THREE.Vector3(...DIRV[dir]);
+  for (const ld of Object.keys(DIRV)) {
+    if (new THREE.Vector3(...DIRV[ld]).applyQuaternion(c0.q).distanceTo(wd) < 1e-6) return c0.colors[ld];
+  }
+  return 'K';
+}
+function faceSVG(list, face, label) {
+  const cell = 17, gap = 1, size = cell * 3 + gap * 2;
+  let rects = '';
+  for (let r = 0; r < 3; r++) for (let c = 0; c < 3; c++) {
+    const col = FACE_COLOR[colorOf(list, face, r, c)] || FACE_COLOR.K;
+    rects += `<rect x="${c*(cell+gap)}" y="${r*(cell+gap)}" width="${cell}" height="${cell}" rx="2.5" fill="${col}" stroke="rgba(0,0,0,.28)" stroke-width="1"/>`;
+  }
+  return `<div class="fc-vis-item"><label>${label}</label><svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">${rects}</svg></div>`;
+}
+function faceSVG_top(list, label) {
+  const cell = 17, gap = 1, size = cell * 3 + gap * 2;
+  let rects = '';
+  for (let r = 0; r < 3; r++) for (let c = 0; c < 3; c++) {
+    const k = colorOf(list, 'U', r, c);
+    const fill = (k === 'U') ? '#ffd500' : '#ececf0';
+    rects += `<rect x="${c*(cell+gap)}" y="${r*(cell+gap)}" width="${cell}" height="${cell}" rx="2.5" fill="${fill}" stroke="rgba(0,0,0,.4)" stroke-width="1"/>`;
+  }
+  return `<div class="fc-vis-item"><label>${label}</label><svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">${rects}</svg></div>`;
+}
+function posSolved(list, pos) {
+  switch (pos) {
+    case 'UFR': return colorOf(list,'F',0,2)==='F' && colorOf(list,'R',0,0)==='R';
+    case 'URB': return colorOf(list,'R',0,2)==='R' && colorOf(list,'B',0,0)==='B';
+    case 'UBL': return colorOf(list,'B',0,2)==='B' && colorOf(list,'L',0,0)==='L';
+    case 'ULF': return colorOf(list,'L',0,2)==='L' && colorOf(list,'F',0,0)==='F';
+    case 'UF': return colorOf(list,'F',0,1)==='F';
+    case 'UR': return colorOf(list,'R',0,1)==='R';
+    case 'UB': return colorOf(list,'B',0,1)==='B';
+    case 'UL': return colorOf(list,'L',0,1)==='L';
+  }
+  return false;
+}
+function faceSVG_pll(list, label) {
+  const cell = 13, gap = 1, u = cell + gap, o = u;
+  const size = u * 5 - gap;
+  let s = '';
+  const rc = (cell, x, y, fill, st) => `<rect x="${x}" y="${y}" width="${cell}" height="${cell}" rx="2.5" fill="${fill}" stroke="${st}" stroke-width="1"/>`;
+  for (let r = 0; r < 3; r++) for (let c = 0; c < 3; c++) {
+    const k = colorOf(list, 'U', r, c);
+    s += rc(cell, o + c*u, o + r*u, (k === 'U') ? '#ffd500' : '#ececf0', 'rgba(0,0,0,.35)');
+  }
+  for (let c = 0; c < 3; c++) {
+    const pos = c === 0 ? 'URB' : (c === 1 ? 'UB' : 'UBL');
+    const k = colorOf(list, 'B', 0, c);
+    s += rc(cell, o + c*u, 0, posSolved(list, pos) ? '#ffd500' : (FACE_COLOR[k] || '#d5d5d9'), 'rgba(0,0,0,.35)');
+  }
+  for (let c = 0; c < 3; c++) {
+    const pos = c === 0 ? 'UFL' : (c === 1 ? 'UF' : 'UFR');
+    const k = colorOf(list, 'F', 0, c);
+    s += rc(cell, o + c*u, 4*u, posSolved(list, pos) ? '#ffd500' : (FACE_COLOR[k] || '#d5d5d9'), 'rgba(0,0,0,.35)');
+  }
+  for (let r = 0; r < 3; r++) {
+    const pos = r === 0 ? 'UBL' : (r === 1 ? 'UL' : 'ULF');
+    const k = colorOf(list, 'L', 0, r);
+    s += rc(cell, 0, o + r*u, posSolved(list, pos) ? '#ffd500' : (FACE_COLOR[k] || '#d5d5d9'), 'rgba(0,0,0,.35)');
+  }
+  for (let r = 0; r < 3; r++) {
+    const pos = r === 0 ? 'URB' : (r === 1 ? 'UR' : 'UFR');
+    const k = colorOf(list, 'R', 0, 2 - r);
+    s += rc(cell, 4*u, o + r*u, posSolved(list, pos) ? '#ffd500' : (FACE_COLOR[k] || '#d5d5d9'), 'rgba(0,0,0,.35)');
+  }
+  return `<div class="fc-vis-item"><label>${label}</label><svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">${s}</svg></div>`;
+}
+function renderFormulaCases() {
+  $all('.fc-alg[data-alg]').forEach(el => {
+    const fwd = wcaToMoves(parseWCA(el.dataset.alg));
+    if (!fwd || fwd.length === 0) return;
+    const tmp = freshCube3();
+    const inv = fwd.slice().reverse().map(m => ({axis: m.axis, layerIdx: m.layerIdx, angleDeg: -m.angleDeg}));
+    applyTo(tmp, inv);
+    const card = el.closest('.fc');
+    const pane = el.closest('.tab-pane');
+    const paneId = pane ? pane.id : '';
+    const name = card.querySelector('.fc-name').textContent;
+    let html = '';
+    if (paneId === 'pane-oll') {
+      html = faceSVG_top(tmp, '顶面 · 黄色块');
+    } else if (paneId === 'pane-pll') {
+      html = faceSVG_pll(tmp, '顶面+侧环 · 黄=已归位');
+    } else if (paneId === 'pane-f2l') {
+      html = faceSVG(tmp, 'U', '顶面 U') + faceSVG(tmp, 'F', '前面 F');
+    } else {
+      if (/十字|小鱼/.test(name)) html = faceSVG_top(tmp, '顶面 · 黄色块');
+      else if (/交换|三棱|对棱|邻棱/.test(name)) html = faceSVG_pll(tmp, '顶面+侧环 · 黄=已归位');
+      else html = faceSVG(tmp, 'U', '顶面 U') + faceSVG(tmp, 'F', '前面 F');
+    }
+    const vis = document.createElement('div');
+    vis.className = 'fc-vis';
+    vis.innerHTML = html;
+    card.appendChild(vis);
+  });
+}
+
+/* ---------- 生命周期 ---------- */
+export function initRubiksCube(root) {
+  if (initialized) return;
+  rootEl = root;
+  stageEl = $('#cubeStage');
+  canvasEl = document.createElement('canvas');
+  canvasEl.id = 'cubeCanvas';
+  stageEl.appendChild(canvasEl);
+  netSvg = $('#net');
+  graphSvg = $('#graphBg');
+
+  bindFormulaModal();
+  bindNetSvg();
+  bind3DCanvas();
+  bindControls();
+  document.addEventListener('keydown', keydownHandler);
+  document.addEventListener('keydown', escFormulaHandler);
+
+  winResizeNet = () => drawNet();
+  window.addEventListener('resize', winResizeNet);
+
+  drawGraphBg();
+  init3D();
+  buildScene();
+  renderFormulaCases();
+  initialized = true;
+}
+
+export function disposeRubiksCube() {
+  if (!initialized) return;
+  if (rafId) cancelAnimationFrame(rafId);
+  if (curPivot) {
+    for (const c of curLayer) cubeGroup.attach(c.mesh);
+    cubeGroup.remove(curPivot);
+    curPivot = null; curLayer = null; curMove = null;
+    syncMeshes();
+  }
+  moveQueue.length = 0;
+  busy = false;
+  if (resizeObserver) { resizeObserver.disconnect(); resizeObserver = null; }
+  if (winResize3d) { window.removeEventListener('resize', winResize3d); winResize3d = null; }
+  if (winResizeNet) { window.removeEventListener('resize', winResizeNet); winResizeNet = null; }
+  document.removeEventListener('keydown', keydownHandler);
+  document.removeEventListener('keydown', escFormulaHandler);
+  if (renderer) { renderer.dispose(); renderer = null; }
+  if (canvasEl && canvasEl.parentNode) canvasEl.parentNode.removeChild(canvasEl);
+  canvasEl = null;
+  rootEl = null;
+  initialized = false;
+}

--- a/toolknit-desktop/src/rubiks-cube-ui.js
+++ b/toolknit-desktop/src/rubiks-cube-ui.js
@@ -1,0 +1,53 @@
+/* ============================================================
+ * rubiks-cube-ui.js —— 图论与魔方 · UI 层
+ * 负责首页「创意」分类入口卡片与 overlay 生命周期，
+ * 打开时初始化核心、关闭时释放资源（符合 ToolKnit 工具模式）
+ * ============================================================ */
+import { initRubiksCube, disposeRubiksCube } from './rubiks-cube-core.js';
+
+const TOOL = 'rubiks-cube';
+const OVERLAY_ID = 'rubiksCubeOverlay';
+
+function initToolUI() {
+  const overlay = document.getElementById(OVERLAY_ID);
+  if (!overlay) return;
+
+  const cards = document.querySelectorAll(`.audio-list-item[data-tool="${TOOL}"]`);
+  const closeBtn = document.getElementById('rubiksCubeBack');
+
+  function open() {
+    if (overlay.classList.contains('visible')) return;
+    overlay.classList.add('visible');
+    initRubiksCube(overlay);
+  }
+  function close() {
+    if (!overlay.classList.contains('visible')) return;
+    disposeRubiksCube();
+    overlay.classList.remove('visible');
+  }
+
+  cards.forEach(card => {
+    card.addEventListener('click', open);
+    card.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+    });
+  });
+  if (closeBtn) closeBtn.addEventListener('click', close);
+
+  // Escape：先关公式面板（core 负责），未开公式面板时关闭整个工具
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape' || !overlay.classList.contains('visible')) return;
+    const modal = overlay.querySelector('.modal-mask');
+    if (modal && !modal.hidden) return;
+    close();
+  });
+
+  // 数据挂载：供主应用调试/扩展
+  window.rubiksCubeTool = { open, close };
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initToolUI);
+} else {
+  initToolUI();
+}

--- a/toolknit-desktop/src/rubiks-cube.css
+++ b/toolknit-desktop/src/rubiks-cube.css
@@ -1,0 +1,248 @@
+/* ============================================================
+ * rubiks-cube.css —— 图论与魔方 · 样式
+ * 所有选择器限定在 #rubiksCubeOverlay 内，变量加 rb- 前缀，
+ * 避免与 ToolKnit 全局样式冲突
+ * ============================================================ */
+
+#rubiksCubeOverlay {
+  --rb-bg-0: #0a0f1e;
+  --rb-bg-1: #0f1830;
+  --rb-panel: rgba(255,255,255,0.035);
+  --rb-panel-2: rgba(255,255,255,0.06);
+  --rb-border: rgba(255,255,255,0.09);
+  --rb-text: #e8eef8;
+  --rb-muted: #8fa2c2;
+  --rb-accent: #5cd6ff;
+  --rb-ok: #3ecf6f;
+  --rb-sticker: #141a2c;
+  font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+  color: var(--rb-text);
+  -webkit-tap-highlight-color: transparent;
+}
+
+#rubiksCubeOverlay *, #rubiksCubeOverlay *::before, #rubiksCubeOverlay *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ---------- overlay 主体布局（标准工具页：左 poster + 右 workspace） ---------- */
+#rubiksCubeOverlay .pdf-merge-v2-poster::after { content: 'CUBE'; }
+#rubiksCubeOverlay .rubiks-cube-workspace {
+  width: 100%;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 18px 22px 24px;
+}
+#rubiksCubeOverlay .rubiks-app {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+#rubiksCubeOverlay .rubiks-header {
+  padding: 4px 2px 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+#rubiksCubeOverlay .rubiks-toolbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; width: 100%; }
+
+#rubiksCubeOverlay .size-switch { display: flex; align-items: center; gap: 4px; }
+#rubiksCubeOverlay .size-switch .lbl { font-size: 12px; color: var(--rb-muted); margin-right: 2px; }
+#rubiksCubeOverlay .size-switch button {
+  width: 30px; height: 30px; border-radius: 8px;
+  border: 1px solid var(--rb-border); background: var(--rb-panel);
+  color: var(--rb-text); font-family: "Orbitron", monospace; font-size: 13px;
+  cursor: pointer; transition: all .15s ease;
+}
+#rubiksCubeOverlay .size-switch button:hover { background: var(--rb-panel-2); }
+#rubiksCubeOverlay .size-switch button.active {
+  background: var(--rb-accent); border-color: var(--rb-accent); color: #06222e;
+  font-weight: 700; box-shadow: 0 0 14px rgba(92,214,255,.45);
+}
+#rubiksCubeOverlay .btn {
+  height: 30px; padding: 0 14px; border-radius: 8px;
+  border: 1px solid var(--rb-border); background: var(--rb-panel);
+  color: var(--rb-text); font-size: 13px; font-weight: 500;
+  cursor: pointer; transition: all .15s ease; font-family: inherit;
+}
+#rubiksCubeOverlay .btn:hover { background: var(--rb-panel-2); }
+#rubiksCubeOverlay .btn.primary { border-color: var(--rb-accent); color: var(--rb-accent); }
+#rubiksCubeOverlay .btn.primary:hover { background: rgba(92,214,255,.12); }
+#rubiksCubeOverlay .rubiks-stats { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--rb-muted); }
+#rubiksCubeOverlay .rubiks-stats b { color: var(--rb-text); font-family: "Orbitron", monospace; font-size: 13px; }
+#rubiksCubeOverlay #solvedBadge {
+  display: none; align-items: center; gap: 5px;
+  padding: 2px 9px; border-radius: 999px;
+  background: rgba(62,207,111,.14); border: 1px solid rgba(62,207,111,.5);
+  color: var(--rb-ok); font-size: 12px; font-weight: 600;
+}
+#rubiksCubeOverlay #solvedBadge.show { display: inline-flex; animation: rubiksPop .5s ease; }
+@keyframes rubiksPop { 0%{transform:scale(.6);opacity:0} 60%{transform:scale(1.08)} 100%{transform:scale(1)} }
+
+/* ---------- 面板 ---------- */
+#rubiksCubeOverlay .rubiks-main {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 0;
+}
+#rubiksCubeOverlay .panel {
+  position: relative;
+  background: var(--rb-panel);
+  border: 1px solid var(--rb-border);
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+#rubiksCubeOverlay .panel-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 14px 7px;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+#rubiksCubeOverlay .panel-title { font-size: 13px; font-weight: 700; letter-spacing: .05em; color: var(--rb-text); }
+#rubiksCubeOverlay .panel-title::before {
+  content: ""; display: inline-block; width: 8px; height: 8px; border-radius: 2px;
+  background: var(--rb-accent); margin-right: 8px; vertical-align: 1px;
+  box-shadow: 0 0 8px rgba(92,214,255,.7);
+}
+#rubiksCubeOverlay .panel-hint { font-size: 11px; color: var(--rb-muted); margin-left: auto; }
+
+#rubiksCubeOverlay .net-panel { flex: 0 0 auto; }
+#rubiksCubeOverlay .net-stage { position: relative; padding: 10px 12px 12px; }
+#rubiksCubeOverlay .graph-bg {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+  pointer-events: none; opacity: .5;
+}
+#rubiksCubeOverlay .graph-bg circle { fill: none; stroke: rgba(140,180,255,.08); }
+#rubiksCubeOverlay .graph-bg .node { fill: rgba(120,200,255,.28); }
+#rubiksCubeOverlay .graph-bg .link { stroke: rgba(140,180,255,.10); fill: none; }
+#rubiksCubeOverlay #net {
+  position: relative;
+  display: block;
+  margin: 0 auto;
+  max-width: 100%;
+  height: auto;
+  touch-action: none;
+  user-select: none;
+  cursor: pointer;
+}
+#rubiksCubeOverlay #net .cell { stroke: rgba(6,10,20,.9); stroke-width: 1.4; }
+#rubiksCubeOverlay #net .cell.hot {
+  stroke: var(--rb-accent); stroke-width: 2.6;
+  filter: drop-shadow(0 0 4px rgba(92,214,255,.9));
+}
+#rubiksCubeOverlay #net .face-label { font-size: 12px; font-weight: 700; fill: rgba(232,238,248,.55); }
+#rubiksCubeOverlay #net .face-label.hot { fill: var(--rb-accent); }
+
+#rubiksCubeOverlay .cube-panel { flex: 0 0 auto; }
+#rubiksCubeOverlay .cube-stage {
+  flex: 1;
+  position: relative;
+  min-height: 380px;
+  touch-action: none;
+  user-select: none;
+}
+#rubiksCubeOverlay #cubeCanvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
+#rubiksCubeOverlay .cube-hint {
+  position: absolute; left: 50%; bottom: 8px; transform: translateX(-50%);
+  font-size: 11px; color: var(--rb-muted); background: rgba(10,15,30,.6);
+  padding: 3px 10px; border-radius: 999px; pointer-events: none;
+  white-space: nowrap;
+}
+
+/* ---------- 控制面板 ---------- */
+#rubiksCubeOverlay .rubiks-footer {
+  padding: 10px 2px 14px;
+  border-top: 1px solid var(--rb-border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+#rubiksCubeOverlay .ctl-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+#rubiksCubeOverlay .ctl-label { font-size: 11px; color: var(--rb-muted); width: 30px; flex: none; }
+#rubiksCubeOverlay .chips { display: flex; gap: 5px; flex-wrap: wrap; }
+#rubiksCubeOverlay .chip {
+  min-width: 34px; height: 32px; padding: 0 9px;
+  border-radius: 8px; border: 1px solid var(--rb-border); background: var(--rb-panel);
+  color: var(--rb-text); font-size: 13px; font-weight: 600; cursor: pointer;
+  transition: all .15s ease; font-family: inherit;
+}
+#rubiksCubeOverlay .chip:hover { background: var(--rb-panel-2); }
+#rubiksCubeOverlay .chip.active { background: var(--rb-accent); border-color: var(--rb-accent); color: #06222e; }
+#rubiksCubeOverlay .chip.face-U.active { background:#f5f5f5; border-color:#f5f5f5; color:#141a2c; }
+#rubiksCubeOverlay .chip.face-D.active { background:#ffd500; border-color:#ffd500; color:#2a2505; }
+#rubiksCubeOverlay .chip.face-F.active { background:#009b48; border-color:#009b48; color:#ffffff; }
+#rubiksCubeOverlay .chip.face-B.active { background:#0051ba; border-color:#0051ba; color:#ffffff; }
+#rubiksCubeOverlay .chip.face-R.active { background:#c41e3a; border-color:#c41e3a; color:#ffffff; }
+#rubiksCubeOverlay .chip.face-L.active { background:#ff5800; border-color:#ff5800; color:#2a1505; }
+#rubiksCubeOverlay .rotate-group { display: flex; align-items: center; gap: 8px; }
+#rubiksCubeOverlay .rotate-btn {
+  height: 34px; padding: 0 16px; border-radius: 9px;
+  border: 1px solid var(--rb-accent); background: rgba(92,214,255,.08);
+  color: var(--rb-accent); font-size: 13px; font-weight: 600; cursor: pointer;
+  transition: all .15s ease; font-family: inherit;
+}
+#rubiksCubeOverlay .rotate-btn:hover { background: rgba(92,214,255,.18); }
+#rubiksCubeOverlay .rotate-btn:active { transform: translateY(1px); }
+#rubiksCubeOverlay .sel-info { font-size: 12px; color: var(--rb-muted); margin-left: auto; }
+#rubiksCubeOverlay .sel-info b { color: var(--rb-accent); font-weight: 600; }
+#rubiksCubeOverlay .key-hint { border-top: 1px solid rgba(255,255,255,.06); padding-top: 8px; margin-top: 2px; }
+#rubiksCubeOverlay .key-hint .key-text { font-size: 11px; color: var(--rb-muted); letter-spacing: .02em; }
+#rubiksCubeOverlay .key-hint .key-text b { color: var(--rb-accent); font-weight: 500; }
+
+/* ---------- 公式面板（overlay 内 modal） ---------- */
+#rubiksCubeOverlay .modal-mask {
+  position: fixed; inset: 0; z-index: 100;
+  background: rgba(4,8,18,.74); backdrop-filter: blur(4px);
+  display: flex; align-items: center; justify-content: center; padding: 20px;
+}
+#rubiksCubeOverlay .modal-mask[hidden] { display: none; }
+#rubiksCubeOverlay .modal {
+  width: min(700px, 100%);
+  max-height: min(86vh, 760px);
+  display: flex; flex-direction: column;
+  background: #0b1226; border: 1px solid var(--rb-border);
+  border-radius: 16px; box-shadow: 0 24px 80px rgba(0,0,0,.55); overflow: hidden;
+}
+#rubiksCubeOverlay .modal-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 16px 20px 12px; border-bottom: 1px solid var(--rb-border); }
+#rubiksCubeOverlay .modal-title { font-size: 18px; font-weight: 700; letter-spacing: .04em; color: var(--rb-accent); font-family: "Orbitron", monospace; }
+#rubiksCubeOverlay .modal-sub { font-size: 11px; color: var(--rb-muted); margin-top: 5px; line-height: 1.7; }
+#rubiksCubeOverlay .modal-sub b { color: #9fe8ff; font-weight: 600; }
+#rubiksCubeOverlay .modal-close { width: 32px; height: 32px; border-radius: 9px; border: 1px solid var(--rb-border); background: var(--rb-panel); color: var(--rb-text); font-size: 20px; line-height: 1; cursor: pointer; flex: none; }
+#rubiksCubeOverlay .modal-close:hover { background: var(--rb-panel-2); }
+#rubiksCubeOverlay .modal-tabs { display: flex; gap: 6px; padding: 10px 16px; border-bottom: 1px solid var(--rb-border); flex-wrap: wrap; }
+#rubiksCubeOverlay .modal-tabs .tab { height: 30px; padding: 0 13px; border-radius: 8px; border: 1px solid var(--rb-border); background: transparent; color: var(--rb-muted); font-size: 12px; font-weight: 600; cursor: pointer; font-family: inherit; }
+#rubiksCubeOverlay .modal-tabs .tab:hover { color: var(--rb-text); background: var(--rb-panel-2); }
+#rubiksCubeOverlay .modal-tabs .tab.active { background: var(--rb-accent); border-color: var(--rb-accent); color: #06222e; }
+#rubiksCubeOverlay .modal-body { padding: 14px 18px 22px; overflow-y: auto; }
+#rubiksCubeOverlay .tab-pane { display: none; }
+#rubiksCubeOverlay .tab-pane.active { display: block; }
+#rubiksCubeOverlay .sec-label { font-size: 12px; color: var(--rb-accent); font-weight: 700; margin: 14px 0 8px; letter-spacing: .06em; }
+#rubiksCubeOverlay .sec-label:first-child { margin-top: 0; }
+#rubiksCubeOverlay .fc { display: flex; align-items: center; gap: 10px; padding: 8px 12px; border: 1px solid var(--rb-border); border-radius: 10px; background: var(--rb-panel); margin-bottom: 8px; flex-wrap: wrap; }
+#rubiksCubeOverlay .fc-name { font-size: 13px; font-weight: 600; min-width: 104px; color: var(--rb-text); }
+#rubiksCubeOverlay .fc-note { font-size: 11px; color: var(--rb-muted); }
+#rubiksCubeOverlay .fc-note-only { font-size: 12px; color: var(--rb-muted); line-height: 1.8; }
+#rubiksCubeOverlay .fc-note-only b { color: #9fe8ff; font-weight: 600; }
+#rubiksCubeOverlay .fc-alg { margin-left: auto; font-family: "Orbitron", monospace; font-size: 13px; color: #9fe8ff; background: rgba(92,214,255,.07); border: 1px solid rgba(92,214,255,.25); border-radius: 8px; padding: 5px 10px; cursor: pointer; user-select: none; transition: all .15s; }
+#rubiksCubeOverlay .fc-alg:hover { background: rgba(92,214,255,.16); }
+#rubiksCubeOverlay .fc-alg .copy-tip { color: var(--rb-ok); font-weight: 700; margin-left: 6px; font-family: "Noto Sans SC", sans-serif; font-size: 11px; }
+#rubiksCubeOverlay .fc-vis { flex-basis: 100%; display: flex; gap: 12px; align-items: flex-start; margin-top: 2px; flex-wrap: wrap; }
+#rubiksCubeOverlay .fc-vis-item { display: flex; flex-direction: column; align-items: center; gap: 3px; }
+#rubiksCubeOverlay .fc-vis-item label { font-size: 10px; color: var(--rb-muted); letter-spacing: .04em; }
+#rubiksCubeOverlay .fc-vis-item svg { border-radius: 6px; box-shadow: 0 2px 12px rgba(0,0,0,.4); }
+
+/* ---------- 响应式 ---------- */
+@media (max-width: 760px) {
+  #rubiksCubeOverlay .rubiks-toolbar { width: 100%; justify-content: space-between; }
+  #rubiksCubeOverlay .panel-hint { display: none; }
+  #rubiksCubeOverlay .cube-stage { min-height: 300px; }
+  #rubiksCubeOverlay .fc-name { min-width: 80px; }
+  #rubiksCubeOverlay .fc-alg { margin-left: 0; }
+}


### PR DESCRIPTION
- 新增 2D 展开图与 3D 魔方实时联动（2-7 阶）
- 支持鼠标拖拽、左右键选层、键盘 WASD/QE/R/Ctrl/Space/数字操控
- 右上角复原公式面板（层先法/CFOP/桥式/ZZ，按阶数适配）
- 创意分类卡片入口 + 帮助中心文档
- 依赖 three.js（npm import）

## Summary

Explain the user-visible change and why it is needed.

## Validation

- [ ] `npm run build`
- [ ] Relevant `npm run test:*` checks
- [ ] `cargo test --locked` when native code changed
- [ ] Help, CLI/MCP guides, and translations updated when needed

## Safety checklist

- [ ] No API key, token, password, private file, or personal path is included
- [ ] Output handling does not overwrite source files or bypass path validation
- [ ] Desktop, CLI, and MCP behavior remain aligned where applicable
- [ ] This pull request is focused and does not include unrelated formatting changes

## Related issue

Fixes #
