### PR TITLE
feat(color-space-compare): add dual color wheels and HEX input

### DIFF
--- a/toolknit-desktop/scripts/test-color-space-compare-core.mjs
+++ b/toolknit-desktop/scripts/test-color-space-compare-core.mjs
@@ -47,6 +47,7 @@ import {
   wheelPointToHsv,
   wheelPointToHue,
   wheelRadiusIsRing,
+  wheelSquareToHsv,
   wheelTriangleBarycentric,
   xyzToAllSpaces,
   xyzToDisplayRgb,
@@ -408,6 +409,33 @@ for (let s = 0; s <= 100; s += 10) {
   }
 }
 
+// The SV square is rasterised from pixel offsets, so its corners must map to
+// the four canonical HSV extremes (white, pure hue, black, black-hue).
+const sqHalf = COLOR_WHEEL_GEOMETRY.squareRadius / Math.SQRT2;
+{
+  const point = wheelSquareToHsv(-sqHalf, -sqHalf, sqHalf);
+  approx(point.s, 0, 1e-12, 'SV top-left saturation');
+  approx(point.v, 100, 1e-12, 'SV top-left value');
+}
+{
+  const point = wheelSquareToHsv(sqHalf, -sqHalf, sqHalf);
+  approx(point.s, 100, 1e-12, 'SV top-right saturation');
+  approx(point.v, 100, 1e-12, 'SV top-right value');
+}
+{
+  const point = wheelSquareToHsv(-sqHalf, sqHalf, sqHalf);
+  approx(point.s, 0, 1e-12, 'SV bottom-left saturation');
+  approx(point.v, 0, 1e-12, 'SV bottom-left value');
+}
+{
+  const point = wheelSquareToHsv(sqHalf, sqHalf, sqHalf);
+  approx(point.s, 100, 1e-12, 'SV bottom-right saturation');
+  approx(point.v, 0, 1e-12, 'SV bottom-right value');
+}
+// centre is 50% saturation, 50% value for any square half-width
+approx(wheelSquareToHsv(0, 0, sqHalf).s, 50, 1e-12, 'SV centre saturation');
+approx(wheelSquareToHsv(0, 0, sqHalf).v, 50, 1e-12, 'SV centre value');
+
 for (let s = 0; s <= 100; s += 10) {
   for (let l = 10; l <= 90; l += 10) {
     const point = hslToWheelPoint(s, l);
@@ -461,11 +489,12 @@ assert.equal(hexCaretAfterSanitize('#1a-2b', 99), 4);
 // The desktop integration must remain discoverable, localizable, and wired
 // through the 2.1 lazy tool shell rather than an isolated iframe.
 const projectRoot = new URL('..', import.meta.url);
-const [html, main, styles, ui, zh, en] = await Promise.all([
+const [html, main, styles, ui, wheel, zh, en] = await Promise.all([
   readFile(new URL('index.html', projectRoot), 'utf8'),
   readFile(new URL('src/main.js', projectRoot), 'utf8'),
   readFile(new URL('src/color-space-compare.css', projectRoot), 'utf8'),
   readFile(new URL('src/color-space-compare-ui.js', projectRoot), 'utf8'),
+  readFile(new URL('src/color-space-compare-wheel.js', projectRoot), 'utf8'),
   readFile(new URL('src/locales/zh.json', projectRoot), 'utf8').then(JSON.parse),
   readFile(new URL('src/locales/en.json', projectRoot), 'utf8').then(JSON.parse),
 ]);
@@ -490,6 +519,8 @@ assert.match(ui, /wheels\?\.relayout\(\)/, 'Opening the page must relayout the w
 assert.match(ui, /wheels\?\.destroy\(\)/, 'Closing the page must release wheel canvas buffers.');
 assert.match(ui, /parseHexColor/, 'The HEX field must be parsed before it is committed.');
 assert.match(ui, /hexInput !== document\.activeElement/, 'Syncing must not overwrite a HEX draft.');
+assert.match(wheel, /wheelSquareToHsv\(px, py, squareHalf\)/, 'The SV square must map pixel offsets via wheelSquareToHsv.');
+assert.doesNotMatch(wheel, /wheelPointToHsv\(px, py\)/, 'The SV square raster must not feed pixel coordinates to the normalised helper.');
 assert.match(styles, /\.color-space-compare-wheel-wrap\s*\{[\s\S]*?aspect-ratio:\s*1/, 'The wheels must stay square.');
 assert.match(styles, /\.color-space-compare-hex-row/, 'The HEX entry row requires dedicated styling.');
 for (const [locale, dictionary] of [['Chinese', zh], ['English', en]]) {

--- a/toolknit-desktop/scripts/test-color-space-compare-core.mjs
+++ b/toolknit-desktop/scripts/test-color-space-compare-core.mjs
@@ -2,12 +2,18 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import {
   COLOR_SPACE_SLIDER_CONFIG,
+  COLOR_WHEEL_GEOMETRY,
+  COLOR_WHEEL_TRIANGLE,
   LAB_D65_WHITE_POINT,
   cmykToRgb,
   fmtColorNumber,
   getSpaceValues,
+  hexCaretAfterSanitize,
   hslToRgb,
+  hslToWheelPoint,
   hsvToRgb,
+  hsvToWheelPoint,
+  hueToWheelPoint,
   labD65ToLch,
   labD65ToRgb,
   labD65ToXyz,
@@ -24,6 +30,7 @@ import {
   oklabToRgb,
   oklabToXyz,
   oklchToOklab,
+  parseHexColor,
   rgbToAllSpaces,
   rgbToCmyk,
   rgbToHex,
@@ -32,9 +39,15 @@ import {
   rgbToLabD65,
   rgbToOklab,
   rgbValuesToXyz,
+  sanitizeHexText,
   srgbToLinear,
   spaceToDisplayRgb,
   spaceToXyz,
+  wheelPointToHsl,
+  wheelPointToHsv,
+  wheelPointToHue,
+  wheelRadiusIsRing,
+  wheelTriangleBarycentric,
   xyzToAllSpaces,
   xyzToDisplayRgb,
   xyzToLabD65,
@@ -384,6 +397,67 @@ for (const space of editableSpaces) {
   }
 }
 
+// Wheel geometry must survive a round trip through every editable pick so the
+// handle drawn on screen always matches the linked HSV/HSL values.
+for (let s = 0; s <= 100; s += 10) {
+  for (let v = 0; v <= 100; v += 10) {
+    const point = hsvToWheelPoint(s, v);
+    const back = wheelPointToHsv(point.x, point.y);
+    approx(back.s, s, 1e-9, `HSV wheel round trip s=${s} v=${v}`);
+    approx(back.v, v, 1e-9, `HSV wheel round trip s=${s} v=${v}`);
+  }
+}
+
+for (let s = 0; s <= 100; s += 10) {
+  for (let l = 10; l <= 90; l += 10) {
+    const point = hslToWheelPoint(s, l);
+    const back = wheelPointToHsl(point.x, point.y);
+    approx(back.s, s, 1e-9, `HSL wheel round trip s=${s} l=${l}`);
+    approx(back.l, l, 1e-9, `HSL wheel round trip s=${s} l=${l}`);
+  }
+}
+
+const triangleVertices = [
+  { name: 'white', vertex: COLOR_WHEEL_TRIANGLE.white, expected: { bW: 1, bK: 0, bC: 0 } },
+  { name: 'black', vertex: COLOR_WHEEL_TRIANGLE.black, expected: { bW: 0, bK: 1, bC: 0 } },
+  { name: 'pure hue', vertex: COLOR_WHEEL_TRIANGLE.pure, expected: { bW: 0, bK: 0, bC: 1 } },
+];
+for (const { name, vertex, expected } of triangleVertices) {
+  approxObject(
+    wheelTriangleBarycentric(vertex.x, vertex.y),
+    expected,
+    1e-12,
+    `HSL triangle ${name} vertex`
+  );
+}
+
+// The hue ring and its indicator dot share one angle convention: 0° points to
+// three o'clock and the angle grows counter-clockwise on screen.
+for (let hue = 0; hue < 360; hue += 15) {
+  const dot = hueToWheelPoint(hue);
+  approx(wheelPointToHue(dot.x, dot.y), hue % 360, 1e-9, `hue indicator ${hue}`);
+  approx(dot.x * dot.x + dot.y * dot.y, COLOR_WHEEL_GEOMETRY.hueDotRadius ** 2, 1e-12, 'hue dot radius');
+}
+approx(wheelPointToHue(1, 0), 0, 1e-12, 'hue at three o clock');
+approx(wheelPointToHue(0, -1), 90, 1e-12, 'hue at twelve o clock');
+assert.equal(wheelRadiusIsRing(COLOR_WHEEL_GEOMETRY.ringSplitRatio), true);
+assert.equal(wheelRadiusIsRing(COLOR_WHEEL_GEOMETRY.ringSplitRatio - 1e-9), false);
+
+// HEX entry must accept the formats people actually paste and reject the rest.
+assert.deepEqual(parseHexColor('#1A2B3C'), { r: 26, g: 43, b: 60 });
+assert.deepEqual(parseHexColor('1a2b3c'), { r: 26, g: 43, b: 60 });
+assert.deepEqual(parseHexColor('#ABC'), { r: 170, g: 187, b: 204 });
+assert.deepEqual(parseHexColor('  #000000  '), { r: 0, g: 0, b: 0 });
+for (const invalid of ['', '#', '12345', '1234567', '#GGGGGG', 'rgb(1,2,3)', null, undefined]) {
+  assert.equal(parseHexColor(invalid), null, `parseHexColor must reject ${JSON.stringify(invalid)}`);
+}
+assert.equal(sanitizeHexText('#1a-2b 3c!!'), '1A2B3C');
+assert.equal(sanitizeHexText('abcdef123456'), 'ABCDEF');
+assert.equal(sanitizeHexText(null), '');
+assert.equal(hexCaretAfterSanitize('#1a-2b', 4), 2);
+assert.equal(hexCaretAfterSanitize('#1a-2b', 0), 0);
+assert.equal(hexCaretAfterSanitize('#1a-2b', 99), 4);
+
 // The desktop integration must remain discoverable, localizable, and wired
 // through the 2.1 lazy tool shell rather than an isolated iframe.
 const projectRoot = new URL('..', import.meta.url);
@@ -410,10 +484,22 @@ assert.match(ui, /resizeObserver\?\.disconnect\(\)/, 'Closing the page must disc
 assert.match(ui, /removeEventListener\('scroll', handleResize\)/, 'Closing the page must release its scroll listener.');
 assert.match(ui, /canvas\.width = 1;[\s\S]*?canvas\.height = 1;/, 'Closing the page must release canvas buffers.');
 assert.match(styles, /\.color-space-compare-sliders\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2/, 'The desktop two-column controls layout is required.');
+assert.match(ui, /createColorWheels/, 'The tool must mount the linked HSV and HSL colour wheels.');
+assert.match(ui, /wheels\?\.sync\(\)/, 'Every update must sync the wheels.');
+assert.match(ui, /wheels\?\.relayout\(\)/, 'Opening the page must relayout the wheels.');
+assert.match(ui, /wheels\?\.destroy\(\)/, 'Closing the page must release wheel canvas buffers.');
+assert.match(ui, /parseHexColor/, 'The HEX field must be parsed before it is committed.');
+assert.match(ui, /hexInput !== document\.activeElement/, 'Syncing must not overwrite a HEX draft.');
+assert.match(styles, /\.color-space-compare-wheel-wrap\s*\{[\s\S]*?aspect-ratio:\s*1/, 'The wheels must stay square.');
+assert.match(styles, /\.color-space-compare-hex-row/, 'The HEX entry row requires dedicated styling.');
 for (const [locale, dictionary] of [['Chinese', zh], ['English', en]]) {
   assert.equal(typeof dictionary.home?.colorSpaceCompare?.subtitle, 'string', `${locale} tool copy is missing.`);
   assert.equal(typeof dictionary.home?.colorSpaceCompare?.spaces?.rgb, 'string', `${locale} RGB guidance is missing.`);
   assert.equal(typeof dictionary.home?.colorSpaceCompare?.gamutOutside, 'string', `${locale} gamut guidance is missing.`);
+  assert.equal(typeof dictionary.home?.colorSpaceCompare?.wheelHint, 'string', `${locale} wheel guidance is missing.`);
+  assert.equal(typeof dictionary.home?.colorSpaceCompare?.wheelRoles?.hsv, 'string', `${locale} HSV wheel role is missing.`);
+  assert.equal(typeof dictionary.home?.colorSpaceCompare?.wheelRoles?.hsl, 'string', `${locale} HSL wheel role is missing.`);
+  assert.equal(typeof dictionary.home?.colorSpaceCompare?.hexInputLabel, 'string', `${locale} HEX field label is missing.`);
   assert.equal(typeof dictionary.home?.toolNames?.colorSpaceCompare, 'string', `${locale} tool-list copy is missing.`);
   assert.equal(typeof dictionary.help?.nav?.colorSpaceCompare, 'string', `${locale} help navigation copy is missing.`);
 }

--- a/toolknit-desktop/scripts/test-color-space-compare-runtime.mjs
+++ b/toolknit-desktop/scripts/test-color-space-compare-runtime.mjs
@@ -3,7 +3,16 @@ import {
   COLOR_SPACE_SLIDER_CONFIG,
   fmtColorNumber,
   getSpaceValues,
+  hslToWheelPoint,
+  hsvToWheelPoint,
+  hueToWheelPoint,
+  normalizeSliderValue,
+  parseHexColor,
+  sanitizeHexText,
   spaceToXyz,
+  wheelPointToHsl,
+  wheelPointToHsv,
+  wheelPointToHue,
   xyzToAllSpaces,
   xyzToDisplayRgb,
 } from '../src/color-space-compare-core.js';
@@ -337,5 +346,87 @@ assertSliderTakeover({ dirty: true, sliderKey: 'h' });
 assertSliderTakeover({ dirty: false, sliderKey: 'h' });
 assertSliderTakeover({ dirty: true, sliderKey: 's' });
 assertSliderTakeover({ dirty: false, sliderKey: 's' });
+
+// The colour wheels feed the same linked model as the sliders, so every pick
+// must normalise onto a valid slider step before it is committed.
+const wheelModule = await import('../src/color-space-compare-wheel.js');
+assert.equal(
+  typeof wheelModule.createColorWheels,
+  'function',
+  'The wheel factory must be importable without a DOM.'
+);
+assert.deepEqual(
+  wheelModule.COLOR_WHEEL_KINDS.map(kind => kind.id),
+  ['hsv', 'hsl'],
+  'Both HSV and HSL wheels are required.'
+);
+
+const hsvChannels = COLOR_SPACE_SLIDER_CONFIG.hsv.channels;
+const hslChannels = COLOR_SPACE_SLIDER_CONFIG.hsl.channels;
+const [hueChannel, saturationChannel] = hsvChannels;
+for (let step = 0; step < 720; step += 1) {
+  const angle = step * 0.5;
+  const dot = hueToWheelPoint(angle);
+  const hue = normalizeSliderValue(wheelPointToHue(dot.x, dot.y), hueChannel);
+  assert.ok(hue >= 0 && hue <= 360, `Wheel hue ${angle} must stay inside the slider range.`);
+  approx(Math.abs(hue / hueChannel.step - Math.round(hue / hueChannel.step)), 0, 1e-9,
+    `Wheel hue ${angle} must land on a slider step.`);
+}
+
+// Pointer positions between the inner shape and the hue ring, and beyond the
+// wheel entirely, must clamp into the editable channel range instead of
+// producing out-of-domain values.
+const strays = [
+  { kind: 'hsv', channels: hsvChannels, picked: wheelPointToHsv(0.9, 0.9) },
+  { kind: 'hsv', channels: hsvChannels, picked: wheelPointToHsv(-0.9, -0.9) },
+  { kind: 'hsl', channels: hslChannels, picked: wheelPointToHsl(5, 5) },
+  { kind: 'hsl', channels: hslChannels, picked: wheelPointToHsl(-5, -5) },
+];
+for (const stray of strays) {
+  for (const channel of stray.channels) {
+    const raw = channel.key === 'h' ? 0 : stray.picked[channel.key];
+    const value = normalizeSliderValue(raw, channel);
+    assert.ok(
+      value >= channel.min && value <= channel.max,
+      `Stray ${stray.kind} ${channel.key} pick must clamp into ${channel.min}..${channel.max}.`
+    );
+  }
+}
+
+function approxXyz(actual, expected, message) {
+  approx(actual.x, expected.x, 1e-9, `${message} x`);
+  approx(actual.y, expected.y, 1e-9, `${message} y`);
+  approx(actual.z, expected.z, 1e-9, `${message} z`);
+}
+
+// A wheel pick round-tripped through the shared conversion must reproduce the
+// color the wheel was showing.
+for (const rgb of [{ r: 30, g: 200, b: 120 }, { r: 240, g: 90, b: 20 }, { r: 12, g: 12, b: 240 }]) {
+  const hsv = getConvertedValues('rgb', rgb, 'hsv');
+  const hsl = getConvertedValues('rgb', rgb, 'hsl');
+  const hsvPoint = hsvToWheelPoint(hsv.s, hsv.v);
+  const hslPoint = hslToWheelPoint(hsl.s, hsl.l);
+  approxXyz(
+    spaceToXyz('hsv', { h: hsv.h, ...wheelPointToHsv(hsvPoint.x, hsvPoint.y) }),
+    spaceToXyz('rgb', rgb),
+    'HSV wheel pick must preserve the linked color'
+  );
+  approxXyz(
+    spaceToXyz('hsl', { h: hsl.h, ...wheelPointToHsl(hslPoint.x, hslPoint.y) }),
+    spaceToXyz('rgb', rgb),
+    'HSL wheel pick must preserve the linked color'
+  );
+}
+
+// Typing a HEX value must move the linked model exactly like the sliders do.
+for (const [text, expected] of [['#1A2B3C', { r: 26, g: 43, b: 60 }], ['abc', { r: 170, g: 187, b: 204 }]]) {
+  assert.deepEqual(parseHexColor(text), expected, `parseHexColor(${text})`);
+  const xyz = spaceToXyz('rgb', expected);
+  const presented = xyzToAllSpaces(xyz, xyzToDisplayRgb(xyz.x, xyz.y, xyz.z));
+  approxXyz(spaceToXyz('hsl', presented.hsl), xyz, `HEX ${text} must reach the shared model`);
+}
+assert.equal(parseHexColor('12'), null, 'Incomplete HEX input must not commit a color.');
+assert.equal(parseHexColor('#12345'), null, 'Five-digit HEX input must be rejected.');
+assert.equal(sanitizeHexText('#1a-2b 3c!!'), '1A2B3C', 'HEX entry must strip separators.');
 
 console.log('Color space compare runtime regression checks passed');

--- a/toolknit-desktop/src/color-space-compare-core.js
+++ b/toolknit-desktop/src/color-space-compare-core.js
@@ -574,3 +574,166 @@ export function normalizeSpaceValues(space, values) {
   }
   return normalized;
 }
+
+/* ------------------------------------------------------------------ *
+ * Color wheel geometry
+ *
+ * Every wheel coordinate is normalised so the wheel's outer radius is 1
+ * and the origin sits at the wheel centre, with y growing downwards to
+ * match screen coordinates. The hue ring is drawn outside the inner
+ * pick shape; `ringSplitRatio` decides which one a pointer press hits.
+ * ------------------------------------------------------------------ */
+
+export const COLOR_WHEEL_GEOMETRY = Object.freeze({
+  ringInnerRadius: 0.80,
+  ringSplitRatio: 0.78,
+  squareRadius: 0.72,
+  triangleRadius: 0.75,
+  hueDotRadius: 0.90,
+});
+
+// HSL triangle vertices on the unit circle (screen coordinates, y down).
+const TRIANGLE_WHITE = Object.freeze({ x: -0.5, y: -0.8660254037844386 });
+const TRIANGLE_BLACK = Object.freeze({ x: -0.5, y: 0.8660254037844386 });
+const TRIANGLE_PURE = Object.freeze({ x: 1, y: 0 });
+const TRIANGLE_ALTITUDE = 1.5;
+const TRIANGLE_DENOMINATOR =
+  (TRIANGLE_BLACK.y - TRIANGLE_PURE.y) * (TRIANGLE_WHITE.x - TRIANGLE_PURE.x)
+  + (TRIANGLE_PURE.x - TRIANGLE_BLACK.x) * (TRIANGLE_WHITE.y - TRIANGLE_PURE.y);
+
+export const COLOR_WHEEL_TRIANGLE = Object.freeze({
+  white: TRIANGLE_WHITE,
+  black: TRIANGLE_BLACK,
+  pure: TRIANGLE_PURE,
+  altitude: TRIANGLE_ALTITUDE,
+});
+
+function clampUnitTriangle({ bW, bK, bC }) {
+  let white = bW < 0 ? 0 : bW;
+  let black = bK < 0 ? 0 : bK;
+  let pure = bC < 0 ? 0 : bC;
+  const sum = white + black + pure;
+  if (sum > 0) {
+    white /= sum;
+    black /= sum;
+    pure /= sum;
+  } else {
+    white = 0;
+    black = 1;
+    pure = 0;
+  }
+  return { bW: white, bK: black, bC: pure };
+}
+
+/** Barycentric weights of the HSL triangle for a point on its unit circle. */
+export function wheelTriangleBarycentric(vertexX, vertexY) {
+  const bW = ((TRIANGLE_BLACK.y - TRIANGLE_PURE.y) * (vertexX - TRIANGLE_PURE.x)
+    + (TRIANGLE_PURE.x - TRIANGLE_BLACK.x) * (vertexY - TRIANGLE_PURE.y)) / TRIANGLE_DENOMINATOR;
+  const bK = ((TRIANGLE_PURE.y - TRIANGLE_WHITE.y) * (vertexX - TRIANGLE_PURE.x)
+    + (TRIANGLE_WHITE.x - TRIANGLE_PURE.x) * (vertexY - TRIANGLE_PURE.y)) / TRIANGLE_DENOMINATOR;
+  return { bW, bK, bC: 1 - bW - bK };
+}
+
+/** Map an HSV wheel pick to the square's normalised centre coordinates. */
+export function hsvToWheelPoint(s, v) {
+  const half = COLOR_WHEEL_GEOMETRY.squareRadius / Math.SQRT2;
+  return {
+    x: (s / 100 - 0.5) * 2 * half,
+    y: (0.5 - v / 100) * 2 * half,
+  };
+}
+
+/** Map a normalised wheel coordinate inside the SV square back to HSV. */
+export function wheelPointToHsv(x, y) {
+  const half = COLOR_WHEEL_GEOMETRY.squareRadius / Math.SQRT2;
+  const px = Math.max(-half, Math.min(half, x));
+  const py = Math.max(-half, Math.min(half, y));
+  return {
+    s: (px + half) / (2 * half) * 100,
+    v: (1 - (py + half) / (2 * half)) * 100,
+  };
+}
+
+/** Map an HSL wheel pick to the triangle's normalised centre coordinates. */
+export function hslToWheelPoint(s, l) {
+  const L = l / 100;
+  const S = s / 100;
+  const bC = (1 - Math.abs(2 * L - 1)) * S;
+  const bW = L - bC / 2;
+  const bK = 1 - bW - bC;
+  return {
+    x: (bW * TRIANGLE_WHITE.x + bK * TRIANGLE_BLACK.x + bC * TRIANGLE_PURE.x)
+      * COLOR_WHEEL_GEOMETRY.triangleRadius,
+    y: (bW * TRIANGLE_WHITE.y + bK * TRIANGLE_BLACK.y + bC * TRIANGLE_PURE.y)
+      * COLOR_WHEEL_GEOMETRY.triangleRadius,
+  };
+}
+
+/** Map a normalised wheel coordinate inside the SL triangle back to HSL. */
+export function wheelPointToHsl(x, y) {
+  const clamped = clampUnitTriangle(
+    wheelTriangleBarycentric(x / COLOR_WHEEL_GEOMETRY.triangleRadius, y / COLOR_WHEEL_GEOMETRY.triangleRadius)
+  );
+  const L = clamped.bW + clamped.bC / 2;
+  let S = 0;
+  if (clamped.bC > 0) {
+    const denominator = L <= 0.5
+      ? 2 * clamped.bW + clamped.bC
+      : 2 - 2 * clamped.bW - clamped.bC;
+    S = denominator > 0 ? clamped.bC / denominator : 0;
+  }
+  return {
+    s: Math.max(0, Math.min(100, S * 100)),
+    l: Math.max(0, Math.min(100, L * 100)),
+  };
+}
+
+/** Hue in degrees for a normalised wheel coordinate (0° at 3 o'clock). */
+export function wheelPointToHue(x, y) {
+  let hue = Math.atan2(-y, x) * 180 / Math.PI;
+  if (hue < 0) hue += 360;
+  return hue;
+}
+
+/** Normalised wheel coordinate for a hue on the indicator ring. */
+export function hueToWheelPoint(hue) {
+  const radians = hue * Math.PI / 180;
+  return {
+    x: Math.cos(radians) * COLOR_WHEEL_GEOMETRY.hueDotRadius,
+    y: -Math.sin(radians) * COLOR_WHEEL_GEOMETRY.hueDotRadius,
+  };
+}
+
+/** True when a normalised wheel radius lands on the hue ring. */
+export function wheelRadiusIsRing(radius) {
+  return radius >= COLOR_WHEEL_GEOMETRY.ringSplitRatio;
+}
+
+/* ------------------------------------------------------------------ *
+ * HEX text handling
+ * ------------------------------------------------------------------ */
+
+/** Parse a 3- or 6-digit hex colour, tolerating a leading `#`. */
+export function parseHexColor(rawText) {
+  const text = String(rawText ?? '').trim().replace(/#/g, '');
+  if (!/^[0-9a-fA-F]{3}$/.test(text) && !/^[0-9a-fA-F]{6}$/.test(text)) return null;
+  const expanded = text.length === 3
+    ? text.split('').map(char => char + char).join('')
+    : text;
+  return {
+    r: parseInt(expanded.slice(0, 2), 16),
+    g: parseInt(expanded.slice(2, 4), 16),
+    b: parseInt(expanded.slice(4, 6), 16),
+  };
+}
+
+/** Keep only hex digits, upper-case them and cap the length at six. */
+export function sanitizeHexText(rawText) {
+  return String(rawText ?? '').replace(/[^0-9a-fA-F]/g, '').toUpperCase().slice(0, 6);
+}
+
+/** Caret offset inside the sanitized text for a caret in the raw text. */
+export function hexCaretAfterSanitize(rawText, caret) {
+  const before = String(rawText ?? '').slice(0, Math.max(0, Math.trunc(caret) || 0));
+  return before.replace(/[^0-9a-fA-F]/g, '').length;
+}

--- a/toolknit-desktop/src/color-space-compare-core.js
+++ b/toolknit-desktop/src/color-space-compare-core.js
@@ -654,6 +654,20 @@ export function wheelPointToHsv(x, y) {
   };
 }
 
+/**
+ * Map a pixel offset inside the SV square to HSV given the square's pixel
+ * half-width. This is the rasterisation companion to wheelPointToHsv, which
+ * works on normalised unit-circle coordinates instead.
+ */
+export function wheelSquareToHsv(px, py, squareHalf) {
+  const cx = Math.max(-squareHalf, Math.min(squareHalf, px));
+  const cy = Math.max(-squareHalf, Math.min(squareHalf, py));
+  return {
+    s: (cx + squareHalf) / (2 * squareHalf) * 100,
+    v: (1 - (cy + squareHalf) / (2 * squareHalf)) * 100,
+  };
+}
+
 /** Map an HSL wheel pick to the triangle's normalised centre coordinates. */
 export function hslToWheelPoint(s, l) {
   const L = l / 100;

--- a/toolknit-desktop/src/color-space-compare-ui.js
+++ b/toolknit-desktop/src/color-space-compare-ui.js
@@ -2,16 +2,20 @@ import {
   COLOR_SPACE_SLIDER_CONFIG,
   fmtColorNumber,
   getSpaceValues,
+  hexCaretAfterSanitize,
   oklabInAdobeRgb,
   oklabInDisplayP3,
   oklabInRec2020,
   oklabInSrgbGamut,
+  parseHexColor,
   rgbToHex,
+  sanitizeHexText,
   spaceToDisplayRgb,
   spaceToXyz,
   xyzToAllSpaces,
   xyzToDisplayRgb,
 } from './color-space-compare-core.js';
+import { createColorWheels } from './color-space-compare-wheel.js';
 import {
   bindColorNumberInput,
   getColorSliderPresentation,
@@ -29,8 +33,8 @@ const INITIAL_RGB = Object.freeze({ r: 128, g: 128, b: 128 });
 const SPACE_META = Object.freeze([
   { id: 'oklch', label: 'OKLCH', icon: 'sparkles' },
   { id: 'oklab', label: 'OKLab', icon: 'orbit' },
-  { id: 'lab', label: 'CIELAB', icon: 'triangle' },
   { id: 'lch', label: 'CIELCH', icon: 'circle-dashed' },
+  { id: 'lab', label: 'CIELAB', icon: 'triangle' },
   { id: 'rgb', label: 'RGB', icon: 'panel-top' },
   { id: 'hsl', label: 'HSL', icon: 'diamond' },
   { id: 'hsv', label: 'HSV', icon: 'scan' },
@@ -40,8 +44,8 @@ const SPACE_META = Object.freeze([
 const CODE_FORMATS = Object.freeze([
   { id: 'oklch', label: 'OKLCH' },
   { id: 'oklab', label: 'OKLab' },
-  { id: 'lab', label: 'Lab D65' },
   { id: 'lch', label: 'LCh D65' },
+  { id: 'lab', label: 'Lab D65' },
   { id: 'cmyk', label: 'CMYK ≈' },
   { id: 'rgb', label: 'RGB' },
   { id: 'hsl', label: 'HSL' },
@@ -124,6 +128,9 @@ function createColorSpaceCompareController(root, notify) {
 
   const preview = root.querySelector('[data-role="preview"]');
   const hexValue = root.querySelector('[data-role="hex"]');
+  const hexRow = root.querySelector('[data-role="hex-row"]');
+  const hexInput = root.querySelector('[data-role="hex-input"]');
+  const wheelsRoot = root.querySelector('[data-role="wheels"]');
   const gamutBadge = root.querySelector('[data-role="gamut-badge"]');
   const gamutList = root.querySelector('[data-role="gamut-list"]');
   const previewStatus = root.querySelector('[data-role="preview-status"]');
@@ -131,12 +138,14 @@ function createColorSpaceCompareController(root, notify) {
   const slidersRoot = root.querySelector('[data-role="sliders"]');
   const controlsRoot = root.querySelector('.color-space-compare-controls');
 
-  if (!preview || !hexValue || !gamutBadge || !gamutList || !previewStatus || !codeList || !slidersRoot) {
+  if (!preview || !hexValue || !hexRow || !hexInput || !wheelsRoot
+    || !gamutBadge || !gamutList || !previewStatus || !codeList || !slidersRoot) {
     throw new Error('Color space compare markup is incomplete.');
   }
 
   const codeElements = new Map();
   const sliderElements = {};
+  let wheels = null;
   let displayRgb = { ...INITIAL_RGB };
   let canonicalState = { space: 'rgb', values: { ...INITIAL_RGB } };
   let lastPresentedAll = null;
@@ -287,6 +296,61 @@ function createColorSpaceCompareController(root, notify) {
     slidersRoot.replaceChildren(fragment);
   }
 
+  function buildWheels() {
+    wheels = createColorWheels(wheelsRoot, {
+      getValues: space => getEditableSpaceValues(space),
+      applyValues: (space, values) => updateAll(space, values),
+      getDisplayRgb: () => displayRgb,
+    });
+  }
+
+  function wireHexInput() {
+    const syncFromHex = (text) => {
+      const rgb = parseHexColor(text);
+      hexRow.classList.toggle('is-invalid', sanitizeHexText(text).length > 0 && !rgb);
+      if (rgb) updateAll('rgb', rgb);
+    };
+
+    hexInput.addEventListener('input', () => {
+      const raw = hexInput.value;
+      const cleaned = sanitizeHexText(raw);
+      if (cleaned !== raw) {
+        // Keep the caret on the same logical character once illegal
+        // characters have been stripped out from under it.
+        const caret = hexCaretAfterSanitize(raw, hexInput.selectionStart || 0);
+        hexInput.value = cleaned;
+        const position = Math.min(caret, cleaned.length);
+        try {
+          hexInput.setSelectionRange(position, position);
+        } catch {
+          // Selection APIs are unavailable for some input states.
+        }
+      }
+      syncFromHex(cleaned);
+    });
+
+    // Pasted values often start with "#", which maxlength would otherwise
+    // truncate before the colour could be parsed.
+    hexInput.addEventListener('paste', (event) => {
+      const text = event.clipboardData?.getData('text') ?? '';
+      if (!text) return;
+      event.preventDefault();
+      const cleaned = sanitizeHexText(text);
+      hexInput.value = cleaned;
+      syncFromHex(cleaned);
+    });
+
+    hexInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') hexInput.blur();
+    });
+
+    hexInput.addEventListener('blur', () => {
+      const parsed = parseHexColor(hexInput.value) ?? displayRgb;
+      hexInput.value = rgbToHex(parsed.r, parsed.g, parsed.b).slice(1);
+      hexRow.classList.remove('is-invalid');
+    });
+  }
+
   function wireSlider(elements) {
     const { meta, config, hit, input, increase, decrease } = elements;
     let dragging = false;
@@ -419,6 +483,10 @@ function createColorSpaceCompareController(root, notify) {
       const hex = rgbToHex(displayRgb.r, displayRgb.g, displayRgb.b);
       preview.style.backgroundColor = hex;
       hexValue.textContent = hex;
+      if (hexInput !== document.activeElement) {
+        hexInput.value = hex.slice(1);
+        hexRow.classList.remove('is-invalid');
+      }
 
       const codeValues = formatCodeValues(all, displayRgb);
       for (const [id, entry] of codeElements) entry.value.textContent = codeValues[id];
@@ -441,6 +509,7 @@ function createColorSpaceCompareController(root, notify) {
       }
 
       updateGamutInfo(all.oklab);
+      wheels?.sync();
       scheduleCanvasTracks(all);
     } finally {
       isUpdating = false;
@@ -560,6 +629,8 @@ function createColorSpaceCompareController(root, notify) {
       }
     }
 
+    wheels?.refreshLabels(key => t(`home.colorSpaceCompare.wheelRoles.${key}`));
+    hexInput.setAttribute('aria-label', t('home.colorSpaceCompare.hexInputLabel'));
     for (const entry of codeElements.values()) {
       entry.button.setAttribute('aria-label', t('home.colorSpaceCompare.copyValue', {
         format: entry.format.label,
@@ -591,7 +662,9 @@ function createColorSpaceCompareController(root, notify) {
     openDrawFrame = requestAnimationFrame(() => {
       openDrawFrame = requestAnimationFrame(() => {
         openDrawFrame = null;
-        if (isOpen && lastPresentedAll) scheduleCanvasTracks(lastPresentedAll);
+        if (!isOpen) return;
+        wheels?.relayout();
+        if (lastPresentedAll) scheduleCanvasTracks(lastPresentedAll);
       });
     });
   }
@@ -607,6 +680,7 @@ function createColorSpaceCompareController(root, notify) {
     for (const channels of Object.values(sliderElements)) {
       for (const slider of Object.values(channels)) slider.stopDrag?.();
     }
+    wheels?.destroy();
     resizeObserver?.disconnect();
     unsubscribeLanguage?.();
     unsubscribeLanguage = null;
@@ -619,11 +693,15 @@ function createColorSpaceCompareController(root, notify) {
   }
 
   function handleResize() {
-    if (isOpen && lastPresentedAll) scheduleCanvasTracks(lastPresentedAll);
+    if (!isOpen) return;
+    wheels?.sync();
+    if (lastPresentedAll) scheduleCanvasTracks(lastPresentedAll);
   }
 
   buildCodeCards();
   buildSliders();
+  buildWheels();
+  wireHexInput();
   createIcons({ icons, attrs: { 'stroke-width': 1.8 } });
   refreshLanguage();
   updateAll('rgb', INITIAL_RGB);
@@ -658,6 +736,13 @@ export function initColorSpaceCompareTool({
         <span class="tool-page-v2-rail-kicker">COLOR SCIENCE LAB</span>
         <h1 data-csc-i18n="home.toolNames.colorSpaceCompare">${t('home.toolNames.colorSpaceCompare')}</h1>
         <p data-csc-i18n="home.colorSpaceCompare.subtitle">${t('home.colorSpaceCompare.subtitle')}</p>
+        <section class="color-space-compare-wheel-panel">
+          <div class="color-space-compare-wheel-head">
+            <span class="color-space-compare-card-kicker" data-csc-i18n="home.colorSpaceCompare.wheelKicker">${t('home.colorSpaceCompare.wheelKicker')}</span>
+            <p class="color-space-compare-wheel-hint" data-csc-i18n="home.colorSpaceCompare.wheelHint">${t('home.colorSpaceCompare.wheelHint')}</p>
+          </div>
+          <div class="color-space-compare-wheels" data-role="wheels"></div>
+        </section>
         <section class="color-space-compare-preview-card">
           <span class="color-space-compare-card-kicker" data-csc-i18n="home.colorSpaceCompare.livePreview">${t('home.colorSpaceCompare.livePreview')}</span>
           <div class="color-space-compare-preview-row">
@@ -666,6 +751,12 @@ export function initColorSpaceCompareTool({
               <strong class="color-space-compare-hex" data-role="hex">#808080</strong>
               <div data-role="gamut-badge"></div>
             </div>
+          </div>
+          <div class="color-space-compare-hex-row" data-role="hex-row">
+            <span class="color-space-compare-hex-hash" aria-hidden="true">#</span>
+            <input class="color-space-compare-hex-input" data-role="hex-input" type="text" value="808080"
+                   maxlength="8" spellcheck="false" autocomplete="off" autocapitalize="off" />
+            <span class="color-space-compare-hex-tag" data-csc-i18n="home.colorSpaceCompare.hexTag">${t('home.colorSpaceCompare.hexTag')}</span>
           </div>
           <p class="color-space-compare-preview-status" data-role="preview-status"></p>
           <div class="color-space-compare-gamut-list" data-role="gamut-list"></div>

--- a/toolknit-desktop/src/color-space-compare-wheel.js
+++ b/toolknit-desktop/src/color-space-compare-wheel.js
@@ -25,6 +25,7 @@ import {
   wheelPointToHsv,
   wheelPointToHue,
   wheelRadiusIsRing,
+  wheelSquareToHsv,
   wheelTriangleBarycentric,
 } from './color-space-compare-core.js';
 
@@ -158,7 +159,9 @@ function drawInner(wheel, hue) {
         const insideY = squareHalf - Math.abs(py);
         if (insideX > 0 && insideY > 0) {
           alpha = Math.min(1, insideX) * Math.min(1, insideY);
-          const point = wheelPointToHsv(px, py);
+          // px/py are pixel offsets. wheelPointToHsv expects normalised
+          // unit-circle coordinates, so the pixel path uses wheelSquareToHsv.
+          const point = wheelSquareToHsv(px, py, squareHalf);
           const color = hsvToRgb(hue, point.s, point.v);
           r = color.r;
           g = color.g;

--- a/toolknit-desktop/src/color-space-compare-wheel.js
+++ b/toolknit-desktop/src/color-space-compare-wheel.js
@@ -1,0 +1,364 @@
+/**
+ * Dual colour wheels for the colour-space comparison tool.
+ *
+ * HSV renders a hue ring around an SV square; HSL renders a hue ring around
+ * an SL triangle. Both wheels read from and write to the same linked colour
+ * model as the sliders, so dragging either wheel moves every other control.
+ *
+ * All geometry lives in color-space-compare-core.js. This module only owns
+ * canvas rasterisation and pointer wiring, which keeps the maths testable in
+ * a plain Node environment.
+ */
+
+import {
+  COLOR_SPACE_SLIDER_CONFIG,
+  COLOR_WHEEL_GEOMETRY,
+  fmtColorNumber,
+  hslToRgb,
+  hslToWheelPoint,
+  hsvToRgb,
+  hsvToWheelPoint,
+  hueToWheelPoint,
+  normalizeSliderValue,
+  rgbToHex,
+  wheelPointToHsl,
+  wheelPointToHsv,
+  wheelPointToHue,
+  wheelRadiusIsRing,
+  wheelTriangleBarycentric,
+} from './color-space-compare-core.js';
+
+export const COLOR_WHEEL_KINDS = Object.freeze([
+  Object.freeze({ id: 'hsv', label: 'HSV', roleKey: 'hsv' }),
+  Object.freeze({ id: 'hsl', label: 'HSL', roleKey: 'hsl' }),
+]);
+
+function channelConfig(kind) {
+  const config = {};
+  for (const channel of COLOR_SPACE_SLIDER_CONFIG[kind].channels) config[channel.key] = channel;
+  return config;
+}
+
+function createWheelEntry(kind) {
+  const item = document.createElement('div');
+  item.className = 'color-space-compare-wheel';
+  item.dataset.wheel = kind.id;
+
+  const head = document.createElement('div');
+  head.className = 'color-space-compare-wheel-top';
+  const name = document.createElement('span');
+  name.className = 'color-space-compare-wheel-name';
+  name.textContent = kind.label;
+  const role = document.createElement('span');
+  role.className = 'color-space-compare-wheel-role';
+  head.append(name, role);
+
+  const wrap = document.createElement('div');
+  wrap.className = 'color-space-compare-wheel-wrap';
+  const canvas = document.createElement('canvas');
+  canvas.className = 'color-space-compare-wheel-canvas';
+  canvas.setAttribute('aria-hidden', 'true');
+  const overlay = document.createElement('div');
+  overlay.className = 'color-space-compare-wheel-overlay';
+  overlay.dataset.role = 'wheel-hit';
+  overlay.tabIndex = 0;
+  overlay.setAttribute('role', 'application');
+  const hueDot = document.createElement('span');
+  hueDot.className = 'color-space-compare-wheel-hue';
+  hueDot.setAttribute('aria-hidden', 'true');
+  const handle = document.createElement('span');
+  handle.className = 'color-space-compare-wheel-handle';
+  handle.setAttribute('aria-hidden', 'true');
+  wrap.append(canvas, overlay, hueDot, handle);
+
+  const readout = document.createElement('div');
+  readout.className = 'color-space-compare-wheel-readout';
+
+  item.append(head, wrap, readout);
+
+  return {
+    kind,
+    item,
+    role,
+    canvas,
+    overlay,
+    hueDot,
+    handle,
+    readout,
+    ring: document.createElement('canvas'),
+    inner: document.createElement('canvas'),
+    config: channelConfig(kind.id),
+    size: 0,
+    hue: null,
+    mode: null,
+    pointerId: null,
+  };
+}
+
+/** Rasterise the hue ring. It only depends on size, so it is cached. */
+function drawRing(wheel) {
+  const size = wheel.size;
+  const context = wheel.ring.getContext('2d');
+  if (!context) return;
+  const image = context.createImageData(size, size);
+  const data = image.data;
+  const half = size / 2;
+  const innerRadius = half * COLOR_WHEEL_GEOMETRY.ringInnerRadius;
+
+  for (let y = 0; y < size; y += 1) {
+    const py = y + 0.5 - half;
+    for (let x = 0; x < size; x += 1) {
+      const px = x + 0.5 - half;
+      const index = (y * size + x) * 4;
+      const radius = Math.sqrt(px * px + py * py);
+      const alpha = Math.min(1, half - radius) * Math.min(1, radius - innerRadius);
+      if (alpha <= 0) {
+        data[index + 3] = 0;
+        continue;
+      }
+      const color = hsvToRgb(wheelPointToHue(px, py), 100, 100);
+      data[index] = color.r;
+      data[index + 1] = color.g;
+      data[index + 2] = color.b;
+      data[index + 3] = alpha * 255;
+    }
+  }
+  context.putImageData(image, 0, 0);
+}
+
+/** Rasterise the inner pick shape. It depends on the current hue. */
+function drawInner(wheel, hue) {
+  const size = wheel.size;
+  const context = wheel.inner.getContext('2d');
+  if (!context) return;
+  const image = context.createImageData(size, size);
+  const data = image.data;
+  const half = size / 2;
+  const hueColor = hsvToRgb(hue, 100, 100);
+  const hueR = hueColor.r / 255;
+  const hueG = hueColor.g / 255;
+  const hueB = hueColor.b / 255;
+  const radius = half * (wheel.kind.id === 'hsv'
+    ? COLOR_WHEEL_GEOMETRY.squareRadius
+    : COLOR_WHEEL_GEOMETRY.triangleRadius);
+  const squareHalf = radius / Math.SQRT2;
+
+  for (let y = 0; y < size; y += 1) {
+    const py = y + 0.5 - half;
+    for (let x = 0; x < size; x += 1) {
+      const px = x + 0.5 - half;
+      const index = (y * size + x) * 4;
+      let alpha = 0;
+      let r = 0;
+      let g = 0;
+      let b = 0;
+
+      if (wheel.kind.id === 'hsv') {
+        const insideX = squareHalf - Math.abs(px);
+        const insideY = squareHalf - Math.abs(py);
+        if (insideX > 0 && insideY > 0) {
+          alpha = Math.min(1, insideX) * Math.min(1, insideY);
+          const point = wheelPointToHsv(px, py);
+          const color = hsvToRgb(hue, point.s, point.v);
+          r = color.r;
+          g = color.g;
+          b = color.b;
+        }
+      } else {
+        const barycentric = wheelTriangleBarycentric(px / radius, py / radius);
+        const minimum = Math.min(barycentric.bW, barycentric.bK, barycentric.bC);
+        if (minimum > 0) {
+          alpha = Math.min(1, minimum * 1.5 * radius);
+          r = (barycentric.bW + barycentric.bC * hueR) * 255;
+          g = (barycentric.bW + barycentric.bC * hueG) * 255;
+          b = (barycentric.bW + barycentric.bC * hueB) * 255;
+        }
+      }
+
+      if (alpha <= 0) {
+        data[index + 3] = 0;
+        continue;
+      }
+      data[index] = r;
+      data[index + 1] = g;
+      data[index + 2] = b;
+      data[index + 3] = alpha * 255;
+    }
+  }
+  context.putImageData(image, 0, 0);
+}
+
+function renderWheel(wheel) {
+  const context = wheel.canvas.getContext('2d');
+  if (!context) return;
+  context.clearRect(0, 0, wheel.size, wheel.size);
+  context.drawImage(wheel.ring, 0, 0);
+  context.drawImage(wheel.inner, 0, 0);
+}
+
+export function createColorWheels(mount, {
+  getValues,
+  applyValues,
+  getDisplayRgb,
+} = {}) {
+  const wheels = COLOR_WHEEL_KINDS.map(createWheelEntry);
+  if (mount) mount.replaceChildren(...wheels.map(wheel => wheel.item));
+
+  function layout(wheel) {
+    const rect = wheel.canvas.getBoundingClientRect();
+    if (!rect.width) return false;
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    const size = Math.max(16, Math.round(rect.width * dpr));
+    if (size !== wheel.size) {
+      wheel.size = size;
+      for (const canvas of [wheel.canvas, wheel.ring, wheel.inner]) {
+        canvas.width = size;
+        canvas.height = size;
+      }
+      drawRing(wheel);
+      wheel.hue = null;
+    }
+    return true;
+  }
+
+  function pointerToNorm(wheel, event) {
+    const rect = wheel.overlay.getBoundingClientRect();
+    const radius = rect.width / 2;
+    if (!radius) return { x: 0, y: 0, r: 0 };
+    const x = (event.clientX - (rect.left + radius)) / radius;
+    const y = (event.clientY - (rect.top + radius)) / radius;
+    return { x, y, r: Math.sqrt(x * x + y * y) };
+  }
+
+  function applyFromPointer(wheel, event) {
+    const { x, y, r } = pointerToNorm(wheel, event);
+    const values = getValues(wheel.kind.id);
+    if (wheel.mode === 'ring') {
+      values.h = normalizeSliderValue(wheelPointToHue(x, y), wheel.config.h);
+    } else if (wheel.kind.id === 'hsv') {
+      const point = wheelPointToHsv(x, y);
+      values.s = normalizeSliderValue(point.s, wheel.config.s);
+      values.v = normalizeSliderValue(point.v, wheel.config.v);
+    } else {
+      const point = wheelPointToHsl(x, y);
+      values.s = normalizeSliderValue(point.s, wheel.config.s);
+      values.l = normalizeSliderValue(point.l, wheel.config.l);
+    }
+    if (values.h === null || values.s === null
+      || (wheel.kind.id === 'hsv' ? values.v : values.l) === null) return;
+    applyValues(wheel.kind.id, values);
+  }
+
+  function bindPointer(wheel) {
+    wheel.overlay.addEventListener('pointerdown', (event) => {
+      if (event.button !== 0 && event.pointerType === 'mouse') return;
+      const { r } = pointerToNorm(wheel, event);
+      // The wheel is a circle inside a square box; ignore the empty corners
+      // so pressing beside the wheel cannot jump the hue.
+      if (r > 1) return;
+      wheel.mode = wheelRadiusIsRing(r) ? 'ring' : 'inner';
+      wheel.pointerId = event.pointerId;
+      try { wheel.overlay.setPointerCapture(event.pointerId); } catch { /* unsupported */ }
+      event.preventDefault();
+      applyFromPointer(wheel, event);
+    });
+    wheel.overlay.addEventListener('pointermove', (event) => {
+      if (wheel.pointerId !== event.pointerId) return;
+      event.preventDefault();
+      applyFromPointer(wheel, event);
+    });
+    const stop = (event) => {
+      if (wheel.pointerId !== event.pointerId) return;
+      try { wheel.overlay.releasePointerCapture(event.pointerId); } catch { /* already released */ }
+      wheel.pointerId = null;
+      wheel.mode = null;
+    };
+    wheel.overlay.addEventListener('pointerup', stop);
+    wheel.overlay.addEventListener('pointercancel', stop);
+    wheel.overlay.addEventListener('lostpointercapture', stop);
+    wheel.overlay.addEventListener('keydown', (event) => {
+      const horizontal = event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
+      const vertical = event.key === 'ArrowUp' ? 1 : event.key === 'ArrowDown' ? -1 : 0;
+      if (!horizontal && !vertical) return;
+      event.preventDefault();
+      const values = getValues(wheel.kind.id);
+      if (horizontal) {
+        values.h = normalizeSliderValue(values.h + horizontal * 5, wheel.config.h);
+      } else if (wheel.kind.id === 'hsv') {
+        values.s = normalizeSliderValue(values.s + vertical * 2, wheel.config.s);
+        values.v = normalizeSliderValue(values.v + vertical * 2, wheel.config.v);
+      } else {
+        values.s = normalizeSliderValue(values.s + vertical * 2, wheel.config.s);
+        values.l = normalizeSliderValue(values.l + vertical * 2, wheel.config.l);
+      }
+      applyValues(wheel.kind.id, values);
+    });
+  }
+
+  for (const wheel of wheels) bindPointer(wheel);
+
+  function sync(wheel) {
+    if (!layout(wheel)) return;
+    const values = getValues(wheel.kind.id);
+    if (wheel.hue !== values.h) {
+      wheel.hue = values.h;
+      drawInner(wheel, values.h);
+      renderWheel(wheel);
+    }
+
+    const point = wheel.kind.id === 'hsv'
+      ? hsvToWheelPoint(values.s, values.v)
+      : hslToWheelPoint(values.s, values.l);
+    wheel.handle.style.left = `${50 + point.x * 50}%`;
+    wheel.handle.style.top = `${50 + point.y * 50}%`;
+
+    const rgb = getDisplayRgb();
+    wheel.handle.style.background = rgbToHex(rgb.r, rgb.g, rgb.b);
+    const luminance = 0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b;
+    wheel.handle.classList.toggle('is-over-bright', luminance > 165);
+
+    const huePoint = hueToWheelPoint(values.h);
+    const hueColor = hsvToRgb(values.h, 100, 100);
+    wheel.hueDot.style.left = `${50 + huePoint.x * 50}%`;
+    wheel.hueDot.style.top = `${50 + huePoint.y * 50}%`;
+    wheel.hueDot.style.background = rgbToHex(hueColor.r, hueColor.g, hueColor.b);
+
+    const readout = wheel.kind.id === 'hsv'
+      ? { third: 'V', value: values.v }
+      : { third: 'L', value: values.l };
+    wheel.readout.textContent = `H ${fmtColorNumber(values.h, 0)} · S ${fmtColorNumber(values.s, 0)} · ${readout.third} ${fmtColorNumber(readout.value, 0)}`;
+    wheel.overlay.setAttribute('aria-label', `${wheel.kind.label} colour wheel`);
+  }
+
+  return {
+    sync() {
+      for (const wheel of wheels) sync(wheel);
+    },
+    /** Drop cached rasters so the next sync redraws at the new size. */
+    relayout() {
+      for (const wheel of wheels) {
+        wheel.size = 0;
+        sync(wheel);
+      }
+    },
+    refreshLabels(getText) {
+      for (const wheel of wheels) {
+        wheel.role.textContent = getText(wheel.kind.roleKey);
+      }
+    },
+    destroy() {
+      for (const wheel of wheels) {
+        wheel.pointerId = null;
+        wheel.mode = null;
+        // Reset the cached size so the next sync redraws into the resized
+        // buffers instead of reusing the shrunken ones.
+        wheel.size = 0;
+        wheel.hue = null;
+        for (const canvas of [wheel.canvas, wheel.ring, wheel.inner]) {
+          canvas.width = 1;
+          canvas.height = 1;
+        }
+      }
+    },
+  };
+}

--- a/toolknit-desktop/src/color-space-compare.css
+++ b/toolknit-desktop/src/color-space-compare.css
@@ -73,8 +73,134 @@
   scrollbar-width: thin;
 }
 
+.color-space-compare-wheel-panel {
+  margin-top: 18px;
+  padding: 13px;
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: 14px;
+  background: rgba(0, 0, 0, .24);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .035);
+}
+
+.color-space-compare-wheel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.color-space-compare-wheel-hint {
+  margin: 0;
+  color: rgba(255, 255, 255, .42);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1.5;
+  text-align: right;
+}
+
+.color-space-compare-wheels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(104px, 1fr));
+  gap: 10px;
+  margin-top: 11px;
+}
+
+.color-space-compare-wheel {
+  min-width: 0;
+}
+
+.color-space-compare-wheel-top {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 6px;
+}
+
+.color-space-compare-wheel-name {
+  color: #fff;
+  font-family: var(--tk-font-display-en), sans-serif;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .05em;
+}
+
+.color-space-compare-wheel-role {
+  overflow: hidden;
+  color: rgba(255, 255, 255, .4);
+  font-size: 8px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.color-space-compare-wheel-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+}
+
+.color-space-compare-wheel-canvas,
+.color-space-compare-wheel-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.color-space-compare-wheel-canvas {
+  display: block;
+}
+
+.color-space-compare-wheel-overlay {
+  z-index: 4;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.color-space-compare-wheel-overlay:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.color-space-compare-wheel-hue,
+.color-space-compare-wheel-handle {
+  position: absolute;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.color-space-compare-wheel-hue {
+  z-index: 2;
+  width: 11px;
+  height: 11px;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, .5);
+}
+
+.color-space-compare-wheel-handle {
+  z-index: 3;
+  width: 13px;
+  height: 13px;
+  border: 2px solid #fff;
+  background: #808080;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, .55);
+}
+
+.color-space-compare-wheel-handle.is-over-bright {
+  border-color: rgba(0, 0, 0, .58);
+}
+
+.color-space-compare-wheel-readout {
+  margin-top: 6px;
+  color: rgba(255, 255, 255, .6);
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 9px;
+  text-align: center;
+}
+
 .color-space-compare-preview-card {
-  margin-top: 22px;
+  margin-top: 14px;
   padding: 14px;
   border: 1px solid rgba(255, 255, 255, .13);
   border-radius: 14px;
@@ -117,6 +243,61 @@
   color: #fff;
   font-size: 16px;
   letter-spacing: 0;
+}
+
+.color-space-compare-hex-row {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  margin-top: 9px;
+  padding: 0 8px;
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, .045);
+}
+
+.color-space-compare-hex-row:focus-within {
+  border-color: #fff;
+  box-shadow: inset 0 0 0 1px #fff;
+}
+
+.color-space-compare-hex-row.is-invalid {
+  border-color: #ff6b6b;
+  box-shadow: inset 0 0 0 1px rgba(255, 107, 107, .55);
+}
+
+.color-space-compare-hex-hash {
+  color: rgba(255, 255, 255, .42);
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.color-space-compare-hex-input {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #fff;
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.color-space-compare-hex-tag {
+  color: rgba(255, 255, 255, .42);
+  font-family: var(--tk-font-display-en), sans-serif;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: .06em;
 }
 
 .color-space-compare-gamut-badge {

--- a/toolknit-desktop/src/locales/en.json
+++ b/toolknit-desktop/src/locales/en.json
@@ -2017,6 +2017,14 @@
       "increase": "Increase {channel} by {step}",
       "decrease": "Decrease {channel} by {step}",
       "copyValue": "Copy {format} value",
+      "wheelKicker": "COLOR WHEEL",
+      "wheelHint": "Ring sets hue · inner shape sets saturation/lightness",
+      "wheelRoles": {
+        "hsv": "SV square",
+        "hsl": "SL triangle"
+      },
+      "hexInputLabel": "Enter a HEX color value",
+      "hexTag": "HEX",
       "spaces": {
         "oklch": "Perceptual cylindrical model",
         "oklab": "Perceptual Cartesian model",

--- a/toolknit-desktop/src/locales/zh.json
+++ b/toolknit-desktop/src/locales/zh.json
@@ -2017,6 +2017,14 @@
       "increase": "{channel} 增加 {step}",
       "decrease": "{channel} 减少 {step}",
       "copyValue": "复制 {format} 颜色值",
+      "wheelKicker": "COLOR WHEEL",
+      "wheelHint": "外环选色相 · 内部选饱和度/明度",
+      "wheelRoles": {
+        "hsv": "SV 方形",
+        "hsl": "SL 三角"
+      },
+      "hexInputLabel": "输入 HEX 颜色值",
+      "hexTag": "HEX",
       "spaces": {
         "oklch": "感知均匀柱坐标",
         "oklab": "感知均匀直角坐标",


### PR DESCRIPTION
## Summary / 概述

升级「颜色空间对比」工具：

- **双色轮 Dual color wheels**：HSV（色相环 + SV 方形）与 HSL（色相环 + SL 三角），与滑块、色卡、HEX 实时联动。
- **HEX 输入框**：预览卡内可编辑，粘贴自动剥离 `#`、非法态红框提示、失焦规范化回写。
- **顺序调整**：滑块区块与代码卡片中 CIELCH 移至 CIELAB 之前。

几何与 HEX 纯函数全部收敛到 `color-space-compare-core.js`，便于无 DOM 测试；`npm run test:color-space-compare` 核心 + 运行时回归测试全绿。

## Changes / 改动

- `src/color-space-compare-wheel.js`（新增）：双色轮渲染与指针交互
- `src/color-space-compare-core.js`：色轮几何、HEX 解析、`wheelSquareToHsv` 像素映射
- `src/color-space-compare-ui.js`：色轮面板、HEX 输入、CIELCH/CIELAB 换序
- `src/color-space-compare.css`：色轮与 HEX 样式
- `src/locales/{zh,en}.json`：对应文案
- `scripts/test-color-space-compare-{core,runtime}.mjs`：几何往返、越界夹取、HEX 解析、像素映射回归测试
<img width="2560" height="1368" alt="image" src="https://github.com/user-attachments/assets/62a7f970-7b62-4045-a8d4-839c49920114" />
